### PR TITLE
Fix Crash on linux

### DIFF
--- a/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -88,7 +88,7 @@ public class ZenModule {
                 if (fileName.startsWith("scripts.zip\\"))
                     fileName = fileName.substring(12);
                 
-                String[] splitName = fileName.replaceAll("\\.zip", "").split("\\.|\\\\");
+                String[] splitName = fileName.replaceAll("\\.zip", "").split("\\.|\\" + File.separator);
                 PartialScriptReference reference = SymbolScriptReference.getOrCreateReference(environmentGlobal);
                 if(splitName.length != 0)
                     reference.addScriptOrDirectory(environmentScript, Arrays.copyOfRange(splitName, 0, splitName.length - 1));


### PR DESCRIPTION
File Separators and stuff

Side note: 
IntelliJ will say the regex is wrong because it thinks it has an unmatched escape char