### PR TITLE
Some bugs, some features

### DIFF
--- a/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -85,7 +85,7 @@ public class ZenModule {
             
             if(!script.getFunctions().isEmpty() || !script.getGlobals().isEmpty()) {
                 String fileName = script.getFileName();
-                if(fileName.startsWith("scripts.zip\\"))
+                if(fileName.startsWith("scripts.zip" + File.separator))
                     fileName = fileName.substring(12);
                 
                 String[] splitName = fileName.replaceAll("\\.zip", "").split("\\.|\\" + File.separator);

--- a/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -52,7 +52,7 @@ public class ZenModule {
      * @param debug             enable debug mode (outputs classes to generated directory)
      */
     public static void compileScripts(String mainFileName, List<ZenParsedFile> scripts, IEnvironmentGlobal environmentGlobal, boolean debug) {
-        ClassWriter clsMain = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        ClassWriter clsMain = new ZenClassWriter(ClassWriter.COMPUTE_FRAMES);
         clsMain.visitSource(mainFileName, null);
         
         clsMain.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "__ZenMain__", null, internal(Object.class), new String[]{internal(Runnable.class)});
@@ -60,7 +60,7 @@ public class ZenModule {
         mainRun.start();
         
         for(ZenParsedFile script : scripts) {
-            ClassWriter clsScript = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+            ClassWriter clsScript = new ZenClassWriter(ClassWriter.COMPUTE_FRAMES);
             clsScript.visitSource(script.getFileName(), null);
             EnvironmentClass environmentScript = new EnvironmentClass(clsScript, script.getEnvironment());
             
@@ -85,7 +85,7 @@ public class ZenModule {
             
             if(!script.getFunctions().isEmpty() || !script.getGlobals().isEmpty()) {
                 String fileName = script.getFileName();
-                if (fileName.startsWith("scripts.zip\\"))
+                if(fileName.startsWith("scripts.zip\\"))
                     fileName = fileName.substring(12);
                 
                 String[] splitName = fileName.replaceAll("\\.zip", "").split("\\.|\\" + File.separator);

--- a/src/main/java/stanhebben/zenscript/ZenTokener.java
+++ b/src/main/java/stanhebben/zenscript/ZenTokener.java
@@ -79,6 +79,7 @@ public class ZenTokener extends TokenStream {
     public static final int T_VAR = 126;
     public static final int T_VAL = 127;
     public static final int T_WHILE = 128;
+    public static final int T_BREAK = 129;
     public static final int T_NULL = 140;
     public static final int T_TRUE = 141;
     public static final int T_FALSE = 142;
@@ -88,8 +89,8 @@ public class ZenTokener extends TokenStream {
     public static final int T_INSTANCEOF = 668;
     
     private static final HashMap<String, Integer> KEYWORDS;
-    private static final String[] REGEXPS = {"#[^\n]*[\n\\e]", "//[^\n]*[\n\\e]", "/\\*[^\\*]*(\\*|\\*[^/\\*][^\\*]*)*\\*/", "[ \t\r\n]*", "[a-zA-Z_][a-zA-Z_0-9]*", "\\-?(0|[1-9][0-9]*)\\.[0-9]+([eE][\\+\\-]?[0-9]+)?[fFdD]?", "\\-?(0|[1-9][0-9]*)", "\"([^\"\\\\]|\\\\([\'\"\\\\/bfnrt]|u[0-9a-fA-F]{4}))*\"", "\'([^\'\\\\]|\\\\([\'\"\\\\/bfnrt]|u[0-9a-fA-F]{4}))*\'", "\\{", "\\}", "\\[", "\\]", "\\.\\.", "\\.", ",", "\\+=", "\\+", "\\-=", "\\-", "\\*=", "\\*", "/=", "/", "%=", "%", "\\|=", "\\|\\|", "\\|", "&=", "&&", "&", "\\^=", "\\^", "\\?", ":", "\\(", "\\)", "~=", "~", ";", "<=", "<", ">=", ">", "==", "=", "!=", "!", "$"};
-    private static final int[] FINALS = {-1, -1, -1, -1, T_ID, T_FLOATVALUE, T_INTVALUE, T_STRINGVALUE, T_STRINGVALUE, T_AOPEN, T_ACLOSE, T_SQBROPEN, T_SQBRCLOSE, T_DOT2, T_DOT, T_COMMA, T_PLUSASSIGN, T_PLUS, T_MINUSASSIGN, T_MINUS, T_MULASSIGN, T_MUL, T_DIVASSIGN, T_DIV, T_MODASSIGN, T_MOD, T_ORASSIGN, T_OR2, T_OR, T_ANDASSIGN, T_AND2, T_AND, T_XORASSIGN, T_XOR, T_QUEST, T_COLON, T_BROPEN, T_BRCLOSE, T_TILDEASSIGN, T_TILDE, T_SEMICOLON, T_LTEQ, T_LT, T_GTEQ, T_GT, T_EQ, T_ASSIGN, T_NOTEQ, T_NOT, T_DOLLAR};
+    private static final String[] REGEXPS = {"#[^\n]*[\n\\e]", "//[^\n]*[\n\\e]", "/\\*[^\\*]*(\\*|\\*[^/\\*][^\\*]*)*\\*/", "[ \t\r\n]*", "[a-zA-Z_][a-zA-Z_0-9]*", "\\-?(0|[1-9][0-9]*)\\.[0-9]+([eE][\\+\\-]?[0-9]+)?[fFdD]?", "\\-?(0|[1-9][0-9]*)", "0x[A-Fa-f0-9]*", "\"([^\"\\\\]|\\\\([\'\"\\\\/bfnrt]|u[0-9a-fA-F]{4}))*\"", "\'([^\'\\\\]|\\\\([\'\"\\\\/bfnrt]|u[0-9a-fA-F]{4}))*\'", "\\{", "\\}", "\\[", "\\]", "\\.\\.", "\\.", ",", "\\+=", "\\+", "\\-=", "\\-", "\\*=", "\\*", "/=", "/", "%=", "%", "\\|=", "\\|\\|", "\\|", "&=", "&&", "&", "\\^=", "\\^", "\\?", ":", "\\(", "\\)", "~=", "~", ";", "<=", "<", ">=", ">", "==", "=", "!=", "!", "$"};
+    private static final int[] FINALS = {-1, -1, -1, -1, T_ID, T_FLOATVALUE, T_INTVALUE, T_INTVALUE, T_STRINGVALUE, T_STRINGVALUE, T_AOPEN, T_ACLOSE, T_SQBROPEN, T_SQBRCLOSE, T_DOT2, T_DOT, T_COMMA, T_PLUSASSIGN, T_PLUS, T_MINUSASSIGN, T_MINUS, T_MULASSIGN, T_MUL, T_DIVASSIGN, T_DIV, T_MODASSIGN, T_MOD, T_ORASSIGN, T_OR2, T_OR, T_ANDASSIGN, T_AND2, T_AND, T_XORASSIGN, T_XOR, T_QUEST, T_COLON, T_BROPEN, T_BRCLOSE, T_TILDEASSIGN, T_TILDE, T_SEMICOLON, T_LTEQ, T_LT, T_GTEQ, T_GT, T_EQ, T_ASSIGN, T_NOTEQ, T_NOT, T_DOLLAR};
     private static final CompiledDFA DFA = new NFA(REGEXPS, FINALS).toDFA().optimize().compile();
     
     public final boolean ignoreBracketErrors;
@@ -122,6 +123,7 @@ public class ZenTokener extends TokenStream {
         KEYWORDS.put("static", T_STATIC);
         KEYWORDS.put("instanceof", T_INSTANCEOF);
         KEYWORDS.put("while", T_WHILE);
+        KEYWORDS.put("break", T_BREAK);
         
         KEYWORDS.put("null", T_NULL);
         KEYWORDS.put("true", T_TRUE);

--- a/src/main/java/stanhebben/zenscript/ZenTokener.java
+++ b/src/main/java/stanhebben/zenscript/ZenTokener.java
@@ -78,6 +78,7 @@ public class ZenTokener extends TokenStream {
     public static final int T_RETURN = 125;
     public static final int T_VAR = 126;
     public static final int T_VAL = 127;
+    public static final int T_WHILE = 128;
     public static final int T_NULL = 140;
     public static final int T_TRUE = 141;
     public static final int T_FALSE = 142;
@@ -120,6 +121,7 @@ public class ZenTokener extends TokenStream {
         KEYWORDS.put("global", T_GLOBAL);
         KEYWORDS.put("static", T_STATIC);
         KEYWORDS.put("instanceof", T_INSTANCEOF);
+        KEYWORDS.put("while", T_WHILE);
         
         KEYWORDS.put("null", T_NULL);
         KEYWORDS.put("true", T_TRUE);

--- a/src/main/java/stanhebben/zenscript/compiler/ZenClassWriter.java
+++ b/src/main/java/stanhebben/zenscript/compiler/ZenClassWriter.java
@@ -1,0 +1,15 @@
+package stanhebben.zenscript.compiler;
+
+import org.objectweb.asm.ClassWriter;
+
+/**
+ * In some cases visitMaxs threw ClassNotFound Exceptions due to different class loaders/path
+ * Using this one should fix that.
+ * Issue was mostly found in MCF due to a class loader override that didn't affect ASM classes.
+ */
+public class ZenClassWriter extends ClassWriter {
+    
+    public ZenClassWriter(int flags) {
+        super(flags);
+    }
+}

--- a/src/main/java/stanhebben/zenscript/expression/ExpressionFunction.java
+++ b/src/main/java/stanhebben/zenscript/expression/ExpressionFunction.java
@@ -100,7 +100,7 @@ public class ExpressionFunction extends Expression {
     public void compile(boolean result, IEnvironmentMethod environment) {
         if(!result)
             return;
-        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        ClassWriter cw = new ZenClassWriter(ClassWriter.COMPUTE_FRAMES);
         cw.visit(Opcodes.V1_6, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", new String[0]);
         
         MethodOutput constructor = new MethodOutput(cw, Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);

--- a/src/main/java/stanhebben/zenscript/expression/ExpressionJavaLambda.java
+++ b/src/main/java/stanhebben/zenscript/expression/ExpressionJavaLambda.java
@@ -49,7 +49,7 @@ public class ExpressionJavaLambda extends Expression {
         // generate class
         String clsName = environment.makeClassName();
         
-        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        ClassWriter cw = new ZenClassWriter(ClassWriter.COMPUTE_FRAMES);
         cw.visit(Opcodes.V1_6, Opcodes.ACC_PUBLIC, clsName, null, "java/lang/Object", new String[]{internal(interfaceClass)});
         
         MethodOutput constructor = new MethodOutput(cw, Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);

--- a/src/main/java/stanhebben/zenscript/expression/ExpressionJavaLambdaSimpleGeneric.java
+++ b/src/main/java/stanhebben/zenscript/expression/ExpressionJavaLambdaSimpleGeneric.java
@@ -2,10 +2,7 @@ package stanhebben.zenscript.expression;
 
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
-import stanhebben.zenscript.compiler.EnvironmentClass;
-import stanhebben.zenscript.compiler.EnvironmentMethod;
-import stanhebben.zenscript.compiler.IEnvironmentClass;
-import stanhebben.zenscript.compiler.IEnvironmentMethod;
+import stanhebben.zenscript.compiler.*;
 import stanhebben.zenscript.definitions.ParsedFunctionArgument;
 import stanhebben.zenscript.statements.Statement;
 import stanhebben.zenscript.symbols.SymbolArgument;
@@ -74,7 +71,7 @@ public class ExpressionJavaLambdaSimpleGeneric extends Expression {
         // generate class
         String clsName = environment.makeClassName();
 
-        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        ClassWriter cw = new ZenClassWriter(ClassWriter.COMPUTE_FRAMES);
         cw.visit(Opcodes.V1_6, Opcodes.ACC_PUBLIC, clsName, createMethodSignature(), "java/lang/Object", new String[]{internal(interfaceClass)});
 
 

--- a/src/main/java/stanhebben/zenscript/parser/TokenStream.java
+++ b/src/main/java/stanhebben/zenscript/parser/TokenStream.java
@@ -92,6 +92,15 @@ public class TokenStream implements Iterator<Token> {
         return peek().getType() == type;
     }
     
+    public Token optional(int... types) {
+        for(int type : types) {
+            Token token = optional(type);
+            if (token != null)
+                return token;
+        }
+        return null;
+    }
+    
     public Token optional(int type) {
         if(peek() != null && peek().getType() == type) {
             return next();

--- a/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
+++ b/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
@@ -305,7 +305,8 @@ public abstract class ParsedExpression {
     private static ParsedExpression readPrimaryExpression(ZenPosition position, ZenTokener parser, IEnvironmentGlobal environment) {
         switch(parser.peek().getType()) {
             case T_INTVALUE:
-                return new ParsedExpressionValue(position, new ExpressionInt(position, Long.parseLong(parser.next().getValue()), ZenTypeInt.INSTANCE));
+                long l = Long.decode(parser.next().getValue());
+                return new ParsedExpressionValue(position, new ExpressionInt(position, l, Long.bitCount(l) > 32 ? ZenType.LONG : ZenTypeInt.INSTANCE));
             case T_FLOATVALUE:
                 String value = parser.next().getValue();
                 ZenType zenType = ZenTypeDouble.INSTANCE;

--- a/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
+++ b/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
@@ -253,7 +253,7 @@ public abstract class ParsedExpression {
         while(true) {
             Token next = parser.peek();
             if(parser.optional(T_DOT) != null) {
-                Token indexString = parser.optional(T_ID);
+                Token indexString = parser.optional(T_ID, T_VERSION);
                 if(indexString != null) {
                     base = new ParsedExpressionMember(position, base, indexString.getValue());
                 } else {

--- a/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpressionCall.java
+++ b/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpressionCall.java
@@ -25,7 +25,7 @@ public class ParsedExpressionCall extends ParsedExpression {
 
     @Override
     public IPartialExpression compile(IEnvironmentMethod environment, ZenType predictedType) {
-        IPartialExpression cReceiver = receiver.compile(environment, null);
+        IPartialExpression cReceiver = receiver.compile(environment, predictedType);
         ZenType[] predictedTypes = cReceiver.predictCallTypes(arguments.size());
 
         Expression[] cArguments = new Expression[arguments.size()];

--- a/src/main/java/stanhebben/zenscript/statements/Statement.java
+++ b/src/main/java/stanhebben/zenscript/statements/Statement.java
@@ -93,6 +93,11 @@ public abstract class Statement {
                 parser.required(T_SEMICOLON, "; expected");
                 return new StatementNull(t.getPosition());
             }
+            case T_BREAK: {
+                parser.next();
+                parser.required(T_SEMICOLON, "; expected");
+                return new StatementBreak(next.getPosition());
+            }
         }
 
         ZenPosition position = parser.peek().getPosition();
@@ -110,4 +115,8 @@ public abstract class Statement {
     }
 
     public abstract void compile(IEnvironmentMethod environment);
+    
+    public List<Statement> getSubStatements() {
+        return Collections.singletonList(this);
+    }
 }

--- a/src/main/java/stanhebben/zenscript/statements/Statement.java
+++ b/src/main/java/stanhebben/zenscript/statements/Statement.java
@@ -80,6 +80,12 @@ public abstract class Statement {
                 Statement content = read(parser, environment, null);
                 return new StatementForeach(t.getPosition(), names.toArray(new String[names.size()]), source, content);
             }
+            case T_WHILE: {
+                parser.next();
+                ParsedExpression condition = ParsedExpression.read(parser, environment);
+                Statement content = read(parser, environment, null);
+                return new StatementWhileDo(next.getPosition(), content, condition);
+            }
             case T_VERSION: {
                 Token t = parser.next();
                 parser.required(T_INTVALUE, "integer expected");

--- a/src/main/java/stanhebben/zenscript/statements/StatementBlock.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementBlock.java
@@ -3,7 +3,7 @@ package stanhebben.zenscript.statements;
 import stanhebben.zenscript.compiler.*;
 import stanhebben.zenscript.util.ZenPosition;
 
-import java.util.List;
+import java.util.*;
 
 public class StatementBlock extends Statement {
 
@@ -14,7 +14,7 @@ public class StatementBlock extends Statement {
 
         this.statements = statements;
     }
-
+    
     @Override
     public void compile(IEnvironmentMethod environment) {
         IEnvironmentMethod local = new EnvironmentScope(environment);
@@ -24,5 +24,14 @@ public class StatementBlock extends Statement {
                 return;
             }
         }
+    }
+    
+    @Override
+    public List<Statement> getSubStatements() {
+        List<Statement> out = new ArrayList<>();
+        out.add(this);
+        for (Statement statement : statements)
+            out.addAll(statement.getSubStatements());
+        return out;
     }
 }

--- a/src/main/java/stanhebben/zenscript/statements/StatementBreak.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementBreak.java
@@ -4,8 +4,6 @@ import org.objectweb.asm.Label;
 import stanhebben.zenscript.compiler.IEnvironmentMethod;
 import stanhebben.zenscript.util.ZenPosition;
 
-import java.util.*;
-
 public class StatementBreak extends Statement {
     
     private Label exit;
@@ -23,6 +21,6 @@ public class StatementBreak extends Statement {
         if(exit != null)
             environment.getOutput().goTo(exit);
         else
-            environment.error(getPosition(), "Break Statement without proper label, report to the author!");
+            environment.error(getPosition(), "Skipping break statement as it has no proper label. Only use breaks in loops!");
     }
 }

--- a/src/main/java/stanhebben/zenscript/statements/StatementBreak.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementBreak.java
@@ -1,0 +1,28 @@
+package stanhebben.zenscript.statements;
+
+import org.objectweb.asm.Label;
+import stanhebben.zenscript.compiler.IEnvironmentMethod;
+import stanhebben.zenscript.util.ZenPosition;
+
+import java.util.*;
+
+public class StatementBreak extends Statement {
+    
+    private Label exit;
+    
+    public StatementBreak(ZenPosition position) {
+        super(position);
+    }
+    
+    public void setExit(Label exit) {
+        this.exit = exit;
+    }
+    
+    @Override
+    public void compile(IEnvironmentMethod environment) {
+        if(exit != null)
+            environment.getOutput().goTo(exit);
+        else
+            environment.error(getPosition(), "Break Statement without proper label, report to the author!");
+    }
+}

--- a/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
@@ -51,7 +51,13 @@ public class StatementForeach extends Statement {
 
         Label repeat = new Label();
         Label exit = new Label();
-
+    
+        //Allows for break statements, sets the exit label!
+        for (Statement statement : body.getSubStatements()) {
+            if (statement instanceof StatementBreak)
+                ((StatementBreak) statement).setExit(exit);
+        }
+        
         methodOutput.label(repeat);
         iterator.compilePreIterate(localVariables, exit);
         body.compile(local);

--- a/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementForeach.java
@@ -8,6 +8,8 @@ import stanhebben.zenscript.symbols.SymbolLocal;
 import stanhebben.zenscript.type.*;
 import stanhebben.zenscript.util.*;
 
+import java.util.*;
+
 public class StatementForeach extends Statement {
 
     private final String[] varnames;
@@ -56,5 +58,13 @@ public class StatementForeach extends Statement {
         iterator.compilePostIterate(localVariables, exit, repeat);
         methodOutput.label(exit);
         iterator.compileEnd();
+    }
+    
+    @Override
+    public List<Statement> getSubStatements() {
+        List<Statement> out = new ArrayList<>();
+        out.add(this);
+        out.addAll(body.getSubStatements());
+        return out;
     }
 }

--- a/src/main/java/stanhebben/zenscript/statements/StatementIf.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementIf.java
@@ -7,44 +7,56 @@ import stanhebben.zenscript.parser.expression.ParsedExpression;
 import stanhebben.zenscript.type.ZenType;
 import stanhebben.zenscript.util.*;
 
-public class StatementIf extends Statement {
+import java.util.*;
 
+public class StatementIf extends Statement {
+    
     private final ParsedExpression condition;
     private final Statement onThen;
     private final Statement onElse;
-
+    
     public StatementIf(ZenPosition position, ParsedExpression condition, Statement onThen, Statement onElse) {
         super(position);
-
+        
         this.condition = condition;
         this.onThen = onThen;
         this.onElse = onElse;
     }
-
+    
     @Override
     public void compile(IEnvironmentMethod environment) {
         environment.getOutput().position(getPosition());
-
+        
         Expression cCondition = condition.compile(environment, ZenType.BOOL).eval(environment).cast(getPosition(), environment, ZenType.BOOL);
-
+        
         ZenType expressionType = cCondition.getType();
         if(expressionType.canCastImplicit(ZenType.BOOL, environment)) {
             Label labelEnd = new Label();
             Label labelElse = onElse == null ? labelEnd : new Label();
-
+            
             cCondition.compileIf(labelElse, environment);
             onThen.compile(environment);
-
+            
             MethodOutput methodOutput = environment.getOutput();
             if(onElse != null) {
                 methodOutput.goTo(labelEnd);
                 methodOutput.label(labelElse);
                 onElse.compile(environment);
             }
-
+            
             methodOutput.label(labelEnd);
         } else {
             environment.error(getPosition(), "condition is not a boolean");
         }
+    }
+    
+    @Override
+    public List<Statement> getSubStatements() {
+        List<Statement> out = new ArrayList<>();
+        out.add(this);
+        out.addAll(onThen.getSubStatements());
+        if(onElse != null)
+            out.addAll(onElse.getSubStatements());
+        return out;
     }
 }

--- a/src/main/java/stanhebben/zenscript/statements/StatementReturn.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementReturn.java
@@ -8,36 +8,36 @@ import stanhebben.zenscript.type.ZenType;
 import stanhebben.zenscript.util.ZenPosition;
 
 public class StatementReturn extends Statement {
-
+    
     private final ZenType returnType;
     private final ParsedExpression expression;
-
+    
     public StatementReturn(ZenPosition position, ZenType returnType, ParsedExpression expression) {
         super(position);
-
+        
         this.returnType = returnType;
         this.expression = expression;
     }
-
+    
     public ParsedExpression getExpression() {
         return expression;
     }
-
+    
     @Override
     public boolean isReturn() {
         return false;
     }
-
+    
     @Override
     public void compile(IEnvironmentMethod environment) {
         environment.getOutput().position(getPosition());
-
+        
         if(expression == null) {
             environment.getOutput().ret();
         } else {
             Expression cExpression = expression.compile(environment, returnType).eval(environment);
             cExpression.compile(true, environment);
-
+            
             Type returnType = cExpression.getType().toASMType();
             environment.getOutput().returnType(returnType);
         }

--- a/src/main/java/stanhebben/zenscript/statements/StatementWhileDo.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementWhileDo.java
@@ -35,7 +35,8 @@ public class StatementWhileDo extends Statement {
         
         output.label(repeat);
         iterator.compilePreIterate(locals, exit);
-        
+    
+        //Allows for break statements, sets the exit label!
         for (Statement statement : body.getSubStatements()) {
             if (statement instanceof StatementBreak)
                 ((StatementBreak) statement).setExit(exit);

--- a/src/main/java/stanhebben/zenscript/statements/StatementWhileDo.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementWhileDo.java
@@ -1,0 +1,42 @@
+package stanhebben.zenscript.statements;
+
+import org.objectweb.asm.Label;
+import stanhebben.zenscript.compiler.IEnvironmentMethod;
+import stanhebben.zenscript.parser.expression.ParsedExpression;
+import stanhebben.zenscript.type.iterator.IteratorWhileDo;
+import stanhebben.zenscript.util.*;
+
+
+public class StatementWhileDo extends Statement {
+    
+    private final Statement body;
+    private final ParsedExpression condition;
+    
+    public StatementWhileDo(ZenPosition position, Statement body, ParsedExpression condition) {
+        super(position);
+        this.body = body;
+        this.condition = condition;
+        
+    }
+    
+    @Override
+    public void compile(IEnvironmentMethod environment) {
+        MethodOutput output = environment.getOutput();
+        output.position(getPosition());
+        
+        final IteratorWhileDo iterator = new IteratorWhileDo(condition, environment);
+        int[] locals = new int[0];
+        iterator.compileStart(locals);
+        
+        Label repeat = new Label();
+        Label exit = new Label();
+        
+        output.label(repeat);
+        iterator.compilePreIterate(locals, exit);
+        body.compile(environment);
+        iterator.compilePostIterate(locals, exit, repeat);
+        output.label(exit);
+        iterator.compileEnd();
+        
+    }
+}

--- a/src/main/java/stanhebben/zenscript/statements/StatementWhileDo.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementWhileDo.java
@@ -6,6 +6,8 @@ import stanhebben.zenscript.parser.expression.ParsedExpression;
 import stanhebben.zenscript.type.iterator.IteratorWhileDo;
 import stanhebben.zenscript.util.*;
 
+import java.util.*;
+
 
 public class StatementWhileDo extends Statement {
     
@@ -33,10 +35,23 @@ public class StatementWhileDo extends Statement {
         
         output.label(repeat);
         iterator.compilePreIterate(locals, exit);
+        
+        for (Statement statement : body.getSubStatements()) {
+            if (statement instanceof StatementBreak)
+                ((StatementBreak) statement).setExit(exit);
+        }
+        
         body.compile(environment);
         iterator.compilePostIterate(locals, exit, repeat);
         output.label(exit);
         iterator.compileEnd();
-        
+    }
+    
+    @Override
+    public List<Statement> getSubStatements() {
+        List<Statement> out = new ArrayList<>();
+        out.add(this);
+        out.addAll(body.getSubStatements());
+        return out;
     }
 }

--- a/src/main/java/stanhebben/zenscript/type/ZenType.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenType.java
@@ -181,6 +181,10 @@ public abstract class ZenType {
                 returnType = read(parser, environment);
                 base = new ZenTypeFunctionCallable(returnType, argumentTypes.toArray(new ZenType[0]), environment.makeClassName());
                 break;
+            case ZenTokener.T_SQBROPEN:
+                base = new ZenTypeArrayList(read(parser, environment));
+                parser.required(ZenTokener.T_SQBRCLOSE, "] expected");
+                break;
             default:
                 throw new ParseException(next, "Unknown type: " + next.getValue());
         }

--- a/src/main/java/stanhebben/zenscript/type/ZenTypeNative.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeNative.java
@@ -16,6 +16,7 @@ import stanhebben.zenscript.value.IAny;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.Optional;
 
 import static stanhebben.zenscript.util.AnyClassWriter.*;
 import static stanhebben.zenscript.util.ZenTypeUtil.*;
@@ -65,7 +66,7 @@ public class ZenTypeNative extends ZenType {
     public void complete(ITypeRegistry types) {
         int iterator = ITERATOR_NONE;
         Annotation _iteratorAnnotation = null;
-        String _classPkg = cls.getPackage().getName().replace('/', '.');
+        String _classPkg = Optional.ofNullable(cls.getPackage()).map(Package::getName).orElse("null").replace('/', '.');
         String _className = cls.getSimpleName();
         boolean fully = false;
         
@@ -488,9 +489,9 @@ public class ZenTypeNative extends ZenType {
                 return new ExpressionCallVirtual(position, environment, unaryOperator.getMethod(), value);
             }
         }
-    
+        
         for(ZenTypeNative parent : implementing)
-            if (parent.hasTernary(this, operator))
+            if(parent.hasTernary(this, operator))
                 return parent.unary(position, environment, value, operator);
         
         environment.error(position, "operator not supported");
@@ -521,9 +522,9 @@ public class ZenTypeNative extends ZenType {
                 return new ExpressionCallVirtual(position, environment, trinaryOperator.getMethod(), first, second, third);
             }
         }
-    
+        
         for(ZenTypeNative parent : implementing)
-            if (parent.hasTernary(third.getType(), operator))
+            if(parent.hasTernary(third.getType(), operator))
                 return parent.trinary(position, environment, first, second, third, operator);
         
         environment.error(position, "operator not supported");

--- a/src/main/java/stanhebben/zenscript/type/expand/ZenExpandMember.java
+++ b/src/main/java/stanhebben/zenscript/type/expand/ZenExpandMember.java
@@ -131,6 +131,14 @@ public class ZenExpandMember {
 
         @Override
         public Expression eval(IEnvironmentGlobal environment) {
+            if (getter == null) {
+                for(IJavaMethod method : methods) {
+                    if (method.accepts(0))
+                        return new ExpressionCallStatic(position, environment, method);
+                }
+                environment.error(position, "Could not evaluate ZenExpandMember " + name + " in " + type);
+                return new ExpressionInvalid(position);
+            }
             return new ExpressionCallStatic(position, environment, getter);
         }
 
@@ -162,7 +170,11 @@ public class ZenExpandMember {
 
         @Override
         public ZenType getType() {
-            return getter.getReturnType();
+            if (getter != null)
+                return getter.getReturnType();
+            if (methods.size() > 1)
+                return methods.get(0).getReturnType();
+            return ZenType.ANY;
         }
 
         @Override

--- a/src/main/java/stanhebben/zenscript/type/iterator/IteratorIterable.java
+++ b/src/main/java/stanhebben/zenscript/type/iterator/IteratorIterable.java
@@ -10,45 +10,45 @@ import java.util.Iterator;
  * @author Stan
  */
 public class IteratorIterable implements IZenIterator {
-
+    
     private final MethodOutput methodOutput;
     private final ZenType iteratorType;
     private int iterator;
-
+    
     public IteratorIterable(MethodOutput methodOutput, ZenType iteratorType) {
         this.methodOutput = methodOutput;
         this.iteratorType = iteratorType;
     }
-
+    
     @Override
     public void compileStart(int[] locals) {
         iterator = methodOutput.local(Type.getType(Iterator.class));
         methodOutput.invokeInterface(Iterable.class, "iterator", Iterator.class);
         methodOutput.storeObject(iterator);
     }
-
+    
     @Override
     public void compilePreIterate(int[] locals, Label exit) {
         methodOutput.loadObject(iterator);
         methodOutput.invokeInterface(Iterator.class, "hasNext", boolean.class);
         methodOutput.ifEQ(exit);
-
+        
         methodOutput.loadObject(iterator);
         methodOutput.invokeInterface(Iterator.class, "next", Object.class);
         methodOutput.checkCast(iteratorType.toASMType().getInternalName());
         methodOutput.store(iteratorType.toASMType(), locals[0]);
     }
-
+    
     @Override
     public void compilePostIterate(int[] locals, Label exit, Label repeat) {
         methodOutput.goTo(repeat);
     }
-
+    
     @Override
     public ZenType getType(int i) {
         return iteratorType;
     }
-
+    
     @Override
     public void compileEnd() {
     }

--- a/src/main/java/stanhebben/zenscript/type/iterator/IteratorWhileDo.java
+++ b/src/main/java/stanhebben/zenscript/type/iterator/IteratorWhileDo.java
@@ -1,0 +1,46 @@
+package stanhebben.zenscript.type.iterator;
+
+import org.objectweb.asm.Label;
+import stanhebben.zenscript.compiler.IEnvironmentMethod;
+import stanhebben.zenscript.parser.expression.ParsedExpression;
+import stanhebben.zenscript.type.*;
+import stanhebben.zenscript.util.MethodOutput;
+
+public class IteratorWhileDo implements IZenIterator {
+    
+    private ParsedExpression condition;
+    private MethodOutput output;
+    private IEnvironmentMethod environment;
+    
+    public IteratorWhileDo(ParsedExpression condition, IEnvironmentMethod environment) {
+        this.condition = condition;
+        this.output = environment.getOutput();
+        this.environment = environment;
+    }
+    
+    @Override
+    public void compileStart(int[] locals) {
+        //Nothing required since we don't need to call an entrySet or something
+    }
+    
+    @Override
+    public void compilePreIterate(int[] locals, Label exit) {
+        condition.compile(environment, ZenType.BOOL).eval(environment).cast(condition.getPosition(), environment, ZenType.BOOL).compile(true, environment);
+        output.ifEQ(exit);
+    }
+    
+    @Override
+    public void compilePostIterate(int[] locals, Label exit, Label repeat) {
+        output.goTo(repeat);
+    }
+    
+    @Override
+    public void compileEnd() {
+        //Nothing required since we don't need to close anything.
+    }
+    
+    @Override
+    public ZenType getType(int i) {
+        return ZenType.VOID;
+    }
+}

--- a/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
@@ -44,7 +44,7 @@ public class JavaMethod implements IJavaMethod {
         boolean lastOptional = false;
         for(boolean optional : optional) {
             if(lastOptional && !optional)
-                throw new IllegalArgumentException("All optionals need to go at the end of the method declaration");
+                throw new IllegalArgumentException("All optionals need to be placed at the end of the method declaration: " + method.toGenericString());
             lastOptional = optional;
         }
     }

--- a/src/main/java/stanhebben/zenscript/util/AnyClassWriter.java
+++ b/src/main/java/stanhebben/zenscript/util/AnyClassWriter.java
@@ -1,6 +1,7 @@
 package stanhebben.zenscript.util;
 
 import org.objectweb.asm.*;
+import stanhebben.zenscript.compiler.ZenClassWriter;
 import stanhebben.zenscript.type.natives.*;
 import stanhebben.zenscript.value.IAny;
 
@@ -63,7 +64,7 @@ public class AnyClassWriter {
     
     public static byte[] construct(IAnyDefinition definition, String name, Type asmType) {
         try {
-            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+            ClassWriter writer = new ZenClassWriter(ClassWriter.COMPUTE_FRAMES);
             writer.visit(Opcodes.V1_6, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL, name, null, internal(Object.class), new String[]{internal(IAny.class)});
             
             definition.defineMembers(writer);

--- a/src/main/java/stanhebben/zenscript/util/MethodOutput.java
+++ b/src/main/java/stanhebben/zenscript/util/MethodOutput.java
@@ -25,10 +25,10 @@ public class MethodOutput {
         MethodVisitor methodVisitor = cls.visitMethod(access, name, descriptor, signature, exceptions);
         visitor = new LocalVariablesSorter(access, descriptor, methodVisitor);
     }
-
+    
     public MethodOutput(ClassVisitor cls, int access, String name, String descriptor, String signature, String[] exceptions, String[] annotations) {
         MethodVisitor methodVisitor = cls.visitMethod(access, name, descriptor, signature, exceptions);
-        for (String annotation : annotations) {
+        for(String annotation : annotations) {
             methodVisitor.visitAnnotation(annotation, true);
         }
         visitor = new LocalVariablesSorter(access, descriptor, methodVisitor);
@@ -41,11 +41,11 @@ public class MethodOutput {
     public void enableDebug() {
         debug = true;
     }
-
+    
     public LocalVariablesSorter getVisitor() {
         return visitor;
     }
-
+    
     public void start() {
         if(debug)
             System.out.println("--start--");
@@ -377,11 +377,11 @@ public class MethodOutput {
     }
     
     public void iXorVs1() {
-    	if(debug)
+        if(debug)
             System.out.println("iXor against '1'");
         
         visitor.visitInsn(ICONST_1);
-        visitor.visitInsn(IXOR);   
+        visitor.visitInsn(IXOR);
     }
     
     public void iShr() {

--- a/src/test/java/stanhebben/zenscript/Tests.java
+++ b/src/test/java/stanhebben/zenscript/Tests.java
@@ -250,7 +250,7 @@ public class Tests {
     @Test
     public void testWhile() {
         try {
-            ZenModule module = ZenModule.compileScriptString("var i = 0; while i < 10 {print(i); i += 1;} print(\"After loop: \" + i);", "test.zs", compileEnvironment, Test.class.getClassLoader());
+            ZenModule module = ZenModule.compileScriptString("var i = 0; while i < 10 {print(i); i += 1;} print(\"After loop: \" + i); while (i > 0) {if i == 5 break; print(i); i -= 1;} print(\"After loop 2: \" + i);", "test.zs", compileEnvironment, Test.class.getClassLoader());
             Runnable runnable = module.getMain();
             if(runnable != null)
                 runnable.run();
@@ -262,6 +262,10 @@ public class Tests {
             assertEquals(Integer.toString(i), prints.get(i));
         }
         assertEquals("After loop: 10", prints.get(10));
+        for(int i = 10; i > 5; i--) {
+            assertEquals(Integer.toString(i), prints.get(21-i));
+        }
+        assertEquals("After loop 2: 5", prints.get(16));
     }
     
     public static void print(String value) {

--- a/src/test/java/stanhebben/zenscript/Tests.java
+++ b/src/test/java/stanhebben/zenscript/Tests.java
@@ -146,7 +146,7 @@ public class Tests {
     @Test
     public void testCalculations() {
         try {
-            ZenModule module = ZenModule.compileScriptString("print(\"Hello\" ~ \" \" ~ \"World\"); if(3+1 == 2*2) {print(\"Used a calculation!\");}", "test.zs", compileEnvironment, Test.class.getClassLoader());
+            ZenModule module = ZenModule.compileScriptString("print(\"Hello\" ~ \" \" ~ \"World\"); if(3+1 == 2*2) {print(\"Used a calculation!\");} print(0x7fffffffffffffff);", "test.zs", compileEnvironment, Test.class.getClassLoader());
             Runnable runnable = module.getMain();
             if(runnable != null)
                 runnable.run();
@@ -157,6 +157,7 @@ public class Tests {
         }
         assertEquals("Hello World", prints.get(0));
         assertEquals("Used a calculation!", prints.get(1));
+        assertEquals("9223372036854775807", prints.get(2));
     }
     
     @Test

--- a/src/test/java/stanhebben/zenscript/Tests.java
+++ b/src/test/java/stanhebben/zenscript/Tests.java
@@ -232,7 +232,7 @@ public class Tests {
     
     
     @Test
-    public void testContains(){
+    public void testContains() {
         try {
             ZenModule module = ZenModule.compileScriptString("var checkthisString = \"Checking\" as string; var checkforthisString = \"ing\" as string; if (checkthisString in checkforthisString) { print(\"Yes\"); } else { print(\"No\"); }", "test.zs", compileEnvironment, Test.class.getClassLoader());
             Runnable runnable = module.getMain();
@@ -241,9 +241,26 @@ public class Tests {
         } catch(Throwable ex) {
             registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
         }
-    
+        
         assertEquals("Yes", prints.get(0));
+        
+    }
     
+    @Test
+    public void testWhile() {
+        try {
+            ZenModule module = ZenModule.compileScriptString("var i = 0; while i < 10 {print(i); i += 1;} print(\"After loop: \" + i);", "test.zs", compileEnvironment, Test.class.getClassLoader());
+            Runnable runnable = module.getMain();
+            if(runnable != null)
+                runnable.run();
+        } catch(Throwable ex) {
+            registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
+        }
+    
+        for(int i = 0; i < 10; i++) {
+            assertEquals(Integer.toString(i), prints.get(i));
+        }
+        assertEquals("After loop: 10", prints.get(10));
     }
     
     public static void print(String value) {


### PR DESCRIPTION
## Features
- Static methods can be called if the parent type is known (also allows for some sort of enums)
  e.g. `val test as IBlockState = create(1, 2, 3);`
- When a method is evaluated it will check if a parameterless variant exists and execute that instead of throwing an error
- Now use a custom ClassWriter, since MCF's classloader change doesn't affect reflection classes...
- The 'version' token now can be used as member as well.
- Lists can be declared using `[baseType]`
- The IllegalArgumentException for wrongly placed optionals now prints the method name
- Added `while` loop
- Added `break` keyword/statement
- Ints now can be written as hexadecimal notation as well `0xa1b3ff`

## Bugfixes
- Fixed NPE if package name is null
- Fixed zip packages for linux users

## Possible breaks:
- `break` and `while` are reserved keywords now, if ppl use them in scripts they will break.