### PR TITLE
Some internal fixes for Fields and ZenClass references

### DIFF
--- a/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -28,7 +28,8 @@ import static stanhebben.zenscript.util.ZenTypeUtil.internal;
  */
 public class ZenModule {
     
-    private final Map<String, byte[]> classes;
+    public static final Map<String, byte[]> classes = new HashMap<>();
+    public static final Map<String, Class> loadedClasses = new HashMap<>();
     private final MyClassLoader classLoader;
     
     
@@ -36,11 +37,11 @@ public class ZenModule {
      * Constructs a module for the given set of classes. Mostly intended for
      * internal use.
      *
-     * @param classes         classes for module
+     * @param clazzes         classes for module
      * @param baseClassLoader class loader
      */
-    public ZenModule(Map<String, byte[]> classes, ClassLoader baseClassLoader) {
-        this.classes = classes;
+    public ZenModule(Map<String, byte[]> clazzes, ClassLoader baseClassLoader) {
+        classes.putAll(clazzes);
         classLoader = new MyClassLoader(baseClassLoader);
     }
     
@@ -387,8 +388,6 @@ public class ZenModule {
      */
     private class MyClassLoader extends ClassLoader {
         
-        private final Map<String, Class> loadedClasses = new HashMap<>();
-        
         private MyClassLoader(ClassLoader baseClassLoader) {
             super(baseClassLoader);
         }
@@ -399,6 +398,8 @@ public class ZenModule {
                 return loadedClasses.get(name);
             if(classes.containsKey(name)) {
                 final byte[] bytes = classes.get(name);
+                if("__ZenMain__".equals(name))
+                    return defineClass(name, bytes, 0, bytes.length);
                 loadedClasses.put(name, defineClass(name, bytes, 0, bytes.length));
                 return loadedClasses.get(name);
             }
@@ -411,6 +412,8 @@ public class ZenModule {
                 return loadedClasses.get(name);
             if(classes.containsKey(name)) {
                 final byte[] bytes = classes.get(name);
+                if("__ZenMain__".equals(name))
+                    return defineClass(name, bytes, 0, bytes.length);
                 loadedClasses.put(name, defineClass(name, bytes, 0, bytes.length));
                 return loadedClasses.get(name);
             }

--- a/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -387,17 +387,34 @@ public class ZenModule {
      */
     private class MyClassLoader extends ClassLoader {
         
+        private final Map<String, Class> loadedClasses = new HashMap<>();
+        
         private MyClassLoader(ClassLoader baseClassLoader) {
             super(baseClassLoader);
         }
         
         @Override
         public Class<?> findClass(String name) throws ClassNotFoundException {
+            if(loadedClasses.containsKey(name))
+                return loadedClasses.get(name);
             if(classes.containsKey(name)) {
-                return defineClass(name, classes.get(name), 0, classes.get(name).length);
+                final byte[] bytes = classes.get(name);
+                loadedClasses.put(name, defineClass(name, bytes, 0, bytes.length));
+                return loadedClasses.get(name);
             }
-            
             return super.findClass(name);
+        }
+        
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if(loadedClasses.containsKey(name))
+                return loadedClasses.get(name);
+            if(classes.containsKey(name)) {
+                final byte[] bytes = classes.get(name);
+                loadedClasses.put(name, defineClass(name, bytes, 0, bytes.length));
+                return loadedClasses.get(name);
+            }
+            return super.loadClass(name);
         }
     }
 }

--- a/src/main/java/stanhebben/zenscript/ZenParsedFile.java
+++ b/src/main/java/stanhebben/zenscript/ZenParsedFile.java
@@ -137,6 +137,7 @@ public class ZenParsedFile {
                     environment.error(parsedZenClass.position, "Class " + parsedZenClass.name + " already exists!");
                 else {
                     classes.put(parsedZenClass.name, parsedZenClass);
+                    environmentScript.putValue(parsedZenClass.name, new SymbolType(parsedZenClass.type), parsedZenClass.position);
                 }
                 parsedZenClass.writeClass(environmentScript);
             } else {

--- a/src/main/java/stanhebben/zenscript/definitions/zenclasses/ParsedZenClassField.java
+++ b/src/main/java/stanhebben/zenscript/definitions/zenclasses/ParsedZenClassField.java
@@ -136,5 +136,10 @@ public class ParsedZenClassField {
         public boolean isVarargs() {
             return false;
         }
+    
+        @Override
+        public String getErrorDescription() {
+            return "INTERNAL METHOD";
+        }
     }
 }

--- a/src/main/java/stanhebben/zenscript/definitions/zenclasses/ParsedZenClassMethod.java
+++ b/src/main/java/stanhebben/zenscript/definitions/zenclasses/ParsedZenClassMethod.java
@@ -12,30 +12,31 @@ import stanhebben.zenscript.type.*;
 import stanhebben.zenscript.type.natives.*;
 import stanhebben.zenscript.util.MethodOutput;
 
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.IntStream;
 
 import static stanhebben.zenscript.ZenTokener.*;
 
 public class ParsedZenClassMethod {
-
-
+    
+    
     final ParsedFunction method;
     final String className;
-
+    
     public ParsedZenClassMethod(ParsedFunction parse, String className) {
-
+        
         this.method = parse;
         this.className = className;
     }
-
+    
     public static ParsedZenClassMethod parse(ZenTokener parser, EnvironmentScript classEnvironment, String className) {
         Token tName = parser.required(ZenTokener.T_ID, "identifier expected");
-
+        
         // function (argname [as type], argname [as type], ...) [as type] {
         // ...contents... }
         parser.required(T_BROPEN, "( expected");
-
+        
         List<ParsedFunctionArgument> arguments = new ArrayList<>();
         if(parser.optional(T_BRCLOSE) == null) {
             Token argName = parser.required(T_ID, "identifier expected");
@@ -43,54 +44,54 @@ public class ParsedZenClassMethod {
             if(parser.optional(T_AS) != null) {
                 type = ZenType.read(parser, classEnvironment);
             }
-
+            
             arguments.add(new ParsedFunctionArgument(argName.getValue(), type));
-
+            
             while(parser.optional(T_COMMA) != null) {
                 Token argName2 = parser.required(T_ID, "identifier expected");
                 ZenType type2 = ZenTypeAny.INSTANCE;
                 if(parser.optional(T_AS) != null) {
                     type2 = ZenType.read(parser, classEnvironment);
                 }
-
+                
                 arguments.add(new ParsedFunctionArgument(argName2.getValue(), type2));
             }
-
+            
             parser.required(T_BRCLOSE, ") expected");
         }
-
+        
         ZenType type = ZenTypeAny.INSTANCE;
         if(parser.optional(T_AS) != null) {
             type = ZenType.read(parser, classEnvironment);
         }
-
+        
         parser.required(T_AOPEN, "{ expected");
-
+        
         Statement[] statements;
         if(parser.optional(T_ACLOSE) != null) {
             statements = new Statement[0];
         } else {
             ArrayList<Statement> statementsAL = new ArrayList<>();
-
+            
             while(parser.optional(T_ACLOSE) == null) {
                 statementsAL.add(Statement.read(parser, classEnvironment, type));
             }
             statements = statementsAL.toArray(new Statement[statementsAL.size()]);
         }
-
-
+        
+        
         return new ParsedZenClassMethod(new ParsedFunction(tName.getPosition(), tName.getValue(), arguments, type, statements), className);
     }
-
+    
     public void addToMember(ZenNativeMember zenNativeMember) {
         zenNativeMember.addMethod(new ZenClassMethod());
     }
-
+    
     public void writeAll(ClassVisitor newClass, IEnvironmentClass environmentNewClass) {
         String description = method.getSignature();
         MethodOutput methodOutput = new MethodOutput(newClass, Opcodes.ACC_PUBLIC, method.getName(), description, null, null);
         IEnvironmentMethod methodEnvironment = new EnvironmentMethod(methodOutput, environmentNewClass);
-
+        
         List<ParsedFunctionArgument> arguments = method.getArguments();
         for(int i = 0; i < arguments.size(); ) {
             ParsedFunctionArgument argument = arguments.get(i);
@@ -101,7 +102,7 @@ public class ParsedZenClassMethod {
         for(Statement statement : statements) {
             statement.compile(methodEnvironment);
         }
-
+        
         if(method.getReturnType() != ZenType.VOID) {
             if(statements[statements.length - 1] instanceof StatementReturn) {
                 if(((StatementReturn) statements[statements.length - 1]).getExpression() != null) {
@@ -117,53 +118,76 @@ public class ParsedZenClassMethod {
         }
         methodOutput.end();
     }
-
-    private class ZenClassMethod implements IJavaMethod {
-
-
+    
+    public class ZenClassMethod implements IJavaMethod {
+        
         @Override
         public boolean isStatic() {
             return false;
         }
-
+        
         @Override
         public boolean accepts(int numArguments) {
             return method.getArgumentTypes().length == numArguments;
         }
-
+        
         @Override
         public boolean accepts(IEnvironmentGlobal environment, Expression... arguments) {
             return accepts(arguments.length) && IntStream.range(0, arguments.length).allMatch(i -> arguments[i].getType().canCastImplicit(method.getArgumentTypes()[i], environment));
         }
-
+        
         @Override
         public int getPriority(IEnvironmentGlobal environment, Expression... arguments) {
-            return accepts(environment, arguments) ? JavaMethod.PRIORITY_LOW : JavaMethod.PRIORITY_INVALID;
+            return matchesExact(arguments) ? JavaMethod.PRIORITY_HIGH : accepts(environment, arguments) ? JavaMethod.PRIORITY_LOW : JavaMethod.PRIORITY_INVALID;
         }
-
+        
+        private boolean matchesExact(Expression... arguments) {
+            if(!accepts(arguments.length))
+                return false;
+            for(int i = 0; i < arguments.length; i++) {
+                if(arguments[i].getType().toJavaClass() != method.getArgumentTypes()[i].toJavaClass())
+                    return false;
+            }
+            return true;
+        }
+        
         @Override
         public void invokeVirtual(MethodOutput output) {
             output.invokeVirtual(className, method.getName(), method.getSignature());
         }
-
+        
         @Override
         public void invokeStatic(MethodOutput output) {
             throw new UnsupportedOperationException("Cannot statically invoke a virtual method");
         }
-
+        
         @Override
         public ZenType[] getParameterTypes() {
             return method.getArgumentTypes();
         }
-
+        
         @Override
         public ZenType getReturnType() {
             return method.getReturnType();
         }
-
+        
         @Override
         public boolean isVarargs() {
             return false;
+        }
+        
+        @Override
+        public String getErrorDescription() {
+            final StringBuilder builder = new StringBuilder(method.getName()).append("(");
+            
+            for(ZenType zenType : method.getArgumentTypes()) {
+                builder.append(zenType.toString()).append(", ");
+            }
+            
+            final int length = builder.length();
+            builder.delete(length - 2, length);
+            
+            return builder.append(")").toString();
         }
     }
 }

--- a/src/main/java/stanhebben/zenscript/expression/ExpressionArrayGet.java
+++ b/src/main/java/stanhebben/zenscript/expression/ExpressionArrayGet.java
@@ -1,6 +1,6 @@
 package stanhebben.zenscript.expression;
 
-import stanhebben.zenscript.compiler.IEnvironmentMethod;
+import stanhebben.zenscript.compiler.*;
 import stanhebben.zenscript.type.*;
 import stanhebben.zenscript.util.ZenPosition;
 
@@ -34,5 +34,10 @@ public class ExpressionArrayGet extends Expression {
         if(result) {
             environment.getOutput().arrayLoad(baseType.toASMType());
         }
+    }
+    
+    @Override
+    public Expression assign(ZenPosition position, IEnvironmentGlobal environment, Expression other) {
+        return new ExpressionArraySet(position, array, index, other);
     }
 }

--- a/src/main/java/stanhebben/zenscript/type/ZenTypeNative.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeNative.java
@@ -239,9 +239,9 @@ public class ZenTypeNative extends ZenType {
                     
                     
                     final Map<String, ZenNativeMember> memberMap = Modifier.isStatic(field.getModifiers()) ? staticMembers : members;
-                    final ZenNativeMember zenNativeMember = memberMap.get(propertyName);
-    
                     memberMap.putIfAbsent(propertyName, new ZenNativeMember());
+    
+                    final ZenNativeMember zenNativeMember = memberMap.get(propertyName);
                     
                     
                     try {
@@ -255,16 +255,17 @@ public class ZenTypeNative extends ZenType {
                         memberMap.get(getterName).addMethod(getterMethod);
                     }
                     
-                    try {
-                        Method setterMethod = cls.getMethod(setterName, field.getType());
-                        checkSetter(setterMethod, cls);
-                        zenNativeMember.setSetter(new JavaMethod(setterMethod, types));
-                    } catch(NoSuchMethodException e) {
-                        ZenFieldMethod setterMethod = new ZenFieldMethod(field, types, true);
-                        zenNativeMember.setSetter(setterMethod);
-                        memberMap.putIfAbsent(setterName, new ZenNativeMember());
-                        memberMap.get(setterName).addMethod(setterMethod);
-                    }
+                    if(!Modifier.isFinal(field.getModifiers()))
+                        try {
+                            Method setterMethod = cls.getMethod(setterName, field.getType());
+                            checkSetter(setterMethod, cls);
+                            zenNativeMember.setSetter(new JavaMethod(setterMethod, types));
+                        } catch(NoSuchMethodException e) {
+                            ZenFieldMethod setterMethod = new ZenFieldMethod(field, types, true);
+                            zenNativeMember.setSetter(setterMethod);
+                            memberMap.putIfAbsent(setterName, new ZenNativeMember());
+                            memberMap.get(setterName).addMethod(setterMethod);
+                        }
                     
                     
                 }

--- a/src/main/java/stanhebben/zenscript/type/natives/IJavaMethod.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/IJavaMethod.java
@@ -1,8 +1,6 @@
 package stanhebben.zenscript.type.natives;
 
-import com.google.gson.*;
 import stanhebben.zenscript.compiler.IEnvironmentGlobal;
-import stanhebben.zenscript.dump.IDumpable;
 import stanhebben.zenscript.expression.Expression;
 import stanhebben.zenscript.type.ZenType;
 import stanhebben.zenscript.util.MethodOutput;
@@ -29,4 +27,6 @@ public interface IJavaMethod {
     ZenType getReturnType();
     
     boolean isVarargs();
+    
+    String getErrorDescription();
 }

--- a/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
@@ -385,4 +385,25 @@ public class JavaMethod implements IJavaMethod {
     public String toString() {
         return "JavaMethod: " + method.toString();
     }
+    
+    
+    @Override
+    public String getErrorDescription() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("\n").append(method.getName()).append("(");
+        for(int i = 0; i < parameterTypes.length; i++) {
+            ZenType type = parameterTypes[i];
+            for(int i1 = 0; i1 < method.getParameterAnnotations()[i].length; i1++) {
+                Annotation an = method.getParameterAnnotations()[i][i1];
+                builder.append("\u00a7a").append(an.annotationType().getSimpleName()).append(" ");
+            }
+            builder.append("\u00a7r").append(type.toString()).append(", ");
+        }
+    
+        //Removes last ', ' and closes the bracket
+        final int length = builder.length();
+        builder.delete(length - 2, length);
+        builder.append(")");
+        return builder.toString();
+    }
 }

--- a/src/main/java/stanhebben/zenscript/type/natives/JavaMethodGenerated.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/JavaMethodGenerated.java
@@ -56,6 +56,11 @@ public class JavaMethodGenerated implements IJavaMethod {
     }
     
     @Override
+    public String getErrorDescription() {
+        return descriptor;
+    }
+    
+    @Override
     public boolean accepts(int numArguments) {
         if(numArguments > parameterTypes.length) {
             return isVarargs;

--- a/src/main/java/stanhebben/zenscript/type/natives/ZenFieldMethod.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/ZenFieldMethod.java
@@ -74,4 +74,9 @@ public class ZenFieldMethod implements IJavaMethod {
     public boolean isVarargs() {
         return false;
     }
+    
+    @Override
+    public String getErrorDescription() {
+        return "FIELD " + field.getName();
+    }
 }

--- a/src/main/java/stanhebben/zenscript/type/natives/ZenNativeMember.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/ZenNativeMember.java
@@ -133,11 +133,15 @@ public class ZenNativeMember {
         
         @Override
         public Expression eval(IEnvironmentGlobal environment) {
+            if(getter == null)
+                throw new RuntimeException("No Getter found!");
             return new ExpressionCallStatic(position, environment, getter);
         }
         
         @Override
         public Expression assign(ZenPosition position, IEnvironmentGlobal environment, Expression other) {
+            if(setter == null)
+                throw new RuntimeException("No Setter found!");
             return new ExpressionCallStatic(position, environment, setter, other);
         }
         

--- a/src/main/java/stanhebben/zenscript/type/natives/ZenNativeMember.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/ZenNativeMember.java
@@ -133,12 +133,12 @@ public class ZenNativeMember {
         
         @Override
         public Expression eval(IEnvironmentGlobal environment) {
-            return new ExpressionCallStatic(position, environment, setter);
+            return new ExpressionCallStatic(position, environment, getter);
         }
         
         @Override
         public Expression assign(ZenPosition position, IEnvironmentGlobal environment, Expression other) {
-            return new ExpressionCallStatic(position, environment, setter);
+            return new ExpressionCallStatic(position, environment, setter, other);
         }
         
         @Override

--- a/src/main/java/stanhebben/zenscript/util/StringUtil.java
+++ b/src/main/java/stanhebben/zenscript/util/StringUtil.java
@@ -1,5 +1,6 @@
 package stanhebben.zenscript.util;
 
+import stanhebben.zenscript.definitions.zenclasses.ParsedZenClassMethod;
 import stanhebben.zenscript.expression.Expression;
 import stanhebben.zenscript.type.ZenType;
 import stanhebben.zenscript.type.natives.*;
@@ -74,25 +75,8 @@ public class StringUtil {
             }
             message.append(")");
             message.append("\nThis is \u00a7ousually\u00a7r an error in your script, not in the mod");
-            methods.forEach(meth -> {
-                if(meth instanceof JavaMethod) {
-                    JavaMethod m = (JavaMethod) meth;
-                    message.append("\n").append(m.getMethod().getName()).append("(");
-                    for(int i = 0; i < m.getParameterTypes().length; i++) {
-                        ZenType type = m.getParameterTypes()[i];
-                        for(int i1 = 0; i1 < m.getMethod().getParameterAnnotations()[i].length; i1++) {
-                            Annotation an = m.getMethod().getParameterAnnotations()[i][i1];
-                            message.append("\u00a7a").append(an.annotationType().getSimpleName()).append(" ");
-                        }
-                        message.append("\u00a7r").append(type.toString()).append(", ");
-                    }
-                    
-                    //Removes last ', ' and closes the bracket
-                    message.deleteCharAt(message.length()-1);
-                    message.deleteCharAt(message.length()-1);
-                    message.append(")");
-                }
-            });
+            for(IJavaMethod meth : methods)
+                message.append(meth.getErrorDescription());
             return message.toString();
         }
     }

--- a/src/test/java/stanhebben/zenscript/Tests.java
+++ b/src/test/java/stanhebben/zenscript/Tests.java
@@ -30,6 +30,12 @@ public class Tests {
         prints.clear();
     }
     
+    @BeforeEach
+    public void clearClasses() {
+        ZenModule.classes.clear();
+        ZenModule.loadedClasses.clear();
+    }
+    
     @Test
     public void testCompile() {
         try {


### PR DESCRIPTION
- static fields now annotatable with ZenProperties
- Ternary ArraySetOperators should now be recognized correctly, and if not there's at least the correct expression returned.
- Static values should now remain initialized (TODO: Check impact on memory)