### PR TITLE
Large function parameters and ternary type cast

### DIFF
--- a/src/main/java/stanhebben/zenscript/ZenModule.java
+++ b/src/main/java/stanhebben/zenscript/ZenModule.java
@@ -115,9 +115,11 @@ public class ZenModule {
                 EnvironmentMethod methodEnvironment = new EnvironmentMethod(methodOutput, environmentScript);
                 
                 List<ParsedFunctionArgument> arguments = function.getValue().getArguments();
-                for(int i = 0; i < arguments.size(); i++) {
+                for(int i = 0, j = 0; i < arguments.size(); i++) {
                     ParsedFunctionArgument argument = arguments.get(i);
-                    methodEnvironment.putValue(argument.getName(), new SymbolArgument(i, argument.getType()), fn.getPosition());
+                    methodEnvironment.putValue(argument.getName(), new SymbolArgument(i + j, argument.getType()), fn.getPosition());
+                    if(argument.getType().isLarge())
+                        ++j;
                 }
                 
                 methodOutput.start();

--- a/src/main/java/stanhebben/zenscript/annotations/ReturnsSelf.java
+++ b/src/main/java/stanhebben/zenscript/annotations/ReturnsSelf.java
@@ -1,0 +1,7 @@
+package stanhebben.zenscript.annotations;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ReturnsSelf {}

--- a/src/main/java/stanhebben/zenscript/definitions/zenclasses/ParsedZenClass.java
+++ b/src/main/java/stanhebben/zenscript/definitions/zenclasses/ParsedZenClass.java
@@ -7,6 +7,7 @@ import stanhebben.zenscript.definitions.ParsedFunction;
 import stanhebben.zenscript.expression.*;
 import stanhebben.zenscript.expression.partial.IPartialExpression;
 import stanhebben.zenscript.parser.Token;
+import stanhebben.zenscript.symbols.SymbolType;
 import stanhebben.zenscript.type.*;
 import stanhebben.zenscript.type.natives.ZenNativeMember;
 import stanhebben.zenscript.util.*;
@@ -50,6 +51,7 @@ public class ParsedZenClass {
         final String name = id.getValue();
         final ZenPosition position = id.getPosition();
         ParsedZenClass classTemplate = new ParsedZenClass(position, name, environmentGlobal.makeClassNameWithMiddleName(position.getFile().getClassName() + "_" + name + "_"), classEnvironment);
+        classEnvironment.putValue(name, new SymbolType(classTemplate.type), classTemplate.position);
 
         Token keyword;
         while((keyword = parser.optional(T_VAL, T_VAR, T_STATIC, T_ZEN_CONSTRUCTOR, T_FUNCTION)) != null) {

--- a/src/main/java/stanhebben/zenscript/expression/ExpressionCallVirtual.java
+++ b/src/main/java/stanhebben/zenscript/expression/ExpressionCallVirtual.java
@@ -1,8 +1,10 @@
 package stanhebben.zenscript.expression;
 
-import stanhebben.zenscript.compiler.*;
+import stanhebben.zenscript.compiler.IEnvironmentGlobal;
+import stanhebben.zenscript.compiler.IEnvironmentMethod;
 import stanhebben.zenscript.type.ZenType;
-import stanhebben.zenscript.type.natives.*;
+import stanhebben.zenscript.type.natives.IJavaMethod;
+import stanhebben.zenscript.type.natives.JavaMethod;
 import stanhebben.zenscript.util.ZenPosition;
 
 /**
@@ -26,6 +28,8 @@ public class ExpressionCallVirtual extends Expression {
 
     @Override
     public ZenType getType() {
+        if(method instanceof JavaMethod && ((JavaMethod) method).returnsSelf)
+            return receiver.getType();
         return method.getReturnType();
     }
 
@@ -41,5 +45,8 @@ public class ExpressionCallVirtual extends Expression {
         if(method.getReturnType() != ZenType.VOID && !result) {
             environment.getOutput().pop(method.getReturnType().isLarge());
         }
+        
+        if(method instanceof JavaMethod && ((JavaMethod) method).returnsSelf)
+            environment.getOutput().checkCast(receiver.getType().toASMType().getInternalName());
     }
 }

--- a/src/main/java/stanhebben/zenscript/expression/ExpressionConditional.java
+++ b/src/main/java/stanhebben/zenscript/expression/ExpressionConditional.java
@@ -30,10 +30,11 @@ public class ExpressionConditional extends Expression {
         Label lblExit = new Label();
         
         condition.compileIf(lblElse, environment);
-        onIf.compile(result, environment);
+        onIf.cast(getPosition(), environment, getType()).compile(result, environment);
         environment.getOutput().goTo(lblExit);
         environment.getOutput().label(lblElse);
-        onElse.compile(result, environment);
+        onElse.cast(getPosition(), environment, getType()).compile(result, environment);
+        
         environment.getOutput().label(lblExit);
     }
 }

--- a/src/main/java/stanhebben/zenscript/expression/ExpressionFunctionCall.java
+++ b/src/main/java/stanhebben/zenscript/expression/ExpressionFunctionCall.java
@@ -31,6 +31,9 @@ public class ExpressionFunctionCall extends Expression {
             value.compile(true, environment);
         }
         environment.getOutput().invokeVirtual(className, "accept", descriptor);
+        if(returnType != ZenType.VOID && !result) {
+            environment.getOutput().pop(returnType.isLarge());
+        }
     }
     
     @Override

--- a/src/main/java/stanhebben/zenscript/type/ZenTypeZenClass.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeZenClass.java
@@ -70,7 +70,7 @@ public class ZenTypeZenClass extends ZenType {
 
     @Override
     public Type toASMType() {
-        return Type.getType(toJavaClass());
+        return toJavaClass() != null ? Type.getType(toJavaClass()) : Type.getType(getSignature());
     }
 
     @Override

--- a/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
+++ b/src/main/java/stanhebben/zenscript/type/natives/JavaMethod.java
@@ -1,8 +1,6 @@
 package stanhebben.zenscript.type.natives;
 
-import stanhebben.zenscript.annotations.Optional;
-import stanhebben.zenscript.annotations.ZenExpansion;
-import stanhebben.zenscript.annotations.ZenMethodStatic;
+import stanhebben.zenscript.annotations.*;
 import stanhebben.zenscript.compiler.*;
 import stanhebben.zenscript.expression.*;
 import stanhebben.zenscript.type.*;
@@ -22,12 +20,15 @@ public class JavaMethod implements IJavaMethod {
     public static final int PRIORITY_MEDIUM = 2;
     public static final int PRIORITY_HIGH = 3;
     private final Method method;
+    public final boolean returnsSelf;
     private final ZenType[] parameterTypes;
     private final boolean[] optional;
     private final ZenType returnType;
 
     public JavaMethod(Method method, ITypeRegistry types) {
+        
         this.method = method;
+        this.returnsSelf = method.getDeclaredAnnotationsByType(ReturnsSelf.class).length != 0;
 
         returnType = types.getType(method.getGenericReturnType());
         parameterTypes = new ZenType[method.getParameterTypes().length];

--- a/src/test/java/stanhebben/zenscript/MainTest.java
+++ b/src/test/java/stanhebben/zenscript/MainTest.java
@@ -3,10 +3,12 @@ package stanhebben.zenscript;
 import stanhebben.zenscript.compiler.IEnvironmentGlobal;
 import stanhebben.zenscript.impl.*;
 
-import java.io.*;
-import java.util.*;
-
-import static stanhebben.zenscript.ZenModule.compileScripts;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class MainTest {
     
@@ -23,7 +25,7 @@ public class MainTest {
         //Creates a IEnvironmentGlobal needed to compile the scripts
         Map<String, byte[]> classes = new HashMap<>();
         IEnvironmentGlobal environmentGlobal = registry.makeGlobalEnvironment(classes);
-    
+        
         //Loads the script file
         File file = new File("script.zs");
         String fileName = file.getName();

--- a/src/test/java/stanhebben/zenscript/TestBoolOperators.java
+++ b/src/test/java/stanhebben/zenscript/TestBoolOperators.java
@@ -34,6 +34,12 @@ public class TestBoolOperators {
         registry.registerGlobal("print", registry.getStaticFunction(TestBoolOperators.class, "print", String.class));
     }
     
+    private static void assertMany(String... lines) {
+        for(int i = 0; i < lines.length; i++) {
+            assertEquals(lines[i], prints.get(i));
+        }
+    }
+    
     @BeforeEach
     public void clearPrints() {
         prints.clear();
@@ -116,9 +122,7 @@ public class TestBoolOperators {
     @Test
     public void TestAndAndOrder() {
         try {
-            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" +
-                    "printFin(methodTrue() && methodTrue()); printFin(methodTrue() && methodFalse()); printFin(methodFalse() && methodTrue()); printFin(methodFalse() && methodFalse()); ",
-                    "test.zs", compileEnvironment, Test.class.getClassLoader());
+            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" + "printFin(methodTrue() && methodTrue()); printFin(methodTrue() && methodFalse()); printFin(methodFalse() && methodTrue()); printFin(methodFalse() && methodFalse()); ", "test.zs", compileEnvironment, Test.class.getClassLoader());
             Runnable runnable = module.getMain();
             if(runnable != null)
                 runnable.run();
@@ -126,18 +130,13 @@ public class TestBoolOperators {
             registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
         }
         
-        assertMany("methodTrue", "methodTrue", "true", "Fin",
-                "methodTrue", "methodFalse", "false", "Fin",
-                "methodFalse", "false", "Fin",
-                "methodFalse", "false", "Fin");
+        assertMany("methodTrue", "methodTrue", "true", "Fin", "methodTrue", "methodFalse", "false", "Fin", "methodFalse", "false", "Fin", "methodFalse", "false", "Fin");
     }
     
     @Test
     public void TestOrOrOrder() {
         try {
-            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" +
-                            "printFin(methodTrue() || methodTrue()); printFin(methodTrue() || methodFalse()); printFin(methodFalse() || methodTrue()); printFin(methodFalse() || methodFalse()); ",
-                    "test.zs", compileEnvironment, Test.class.getClassLoader());
+            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" + "printFin(methodTrue() || methodTrue()); printFin(methodTrue() || methodFalse()); printFin(methodFalse() || methodTrue()); printFin(methodFalse() || methodFalse()); ", "test.zs", compileEnvironment, Test.class.getClassLoader());
             Runnable runnable = module.getMain();
             if(runnable != null)
                 runnable.run();
@@ -145,10 +144,7 @@ public class TestBoolOperators {
             registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
         }
         
-        assertMany("methodTrue", "true", "Fin",
-                "methodTrue", "true", "Fin",
-                "methodFalse", "methodTrue", "true", "Fin",
-                "methodFalse", "methodFalse", "false", "Fin");
+        assertMany("methodTrue", "true", "Fin", "methodTrue", "true", "Fin", "methodFalse", "methodTrue", "true", "Fin", "methodFalse", "methodFalse", "false", "Fin");
         
         
     }
@@ -156,9 +152,7 @@ public class TestBoolOperators {
     @Test
     public void TestAndOrder() {
         try {
-            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" +
-                            "printFin(methodTrue() & methodTrue()); printFin(methodTrue() & methodFalse()); printFin(methodFalse() & methodTrue()); printFin(methodFalse() & methodFalse()); ",
-                    "test.zs", compileEnvironment, Test.class.getClassLoader());
+            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" + "printFin(methodTrue() & methodTrue()); printFin(methodTrue() & methodFalse()); printFin(methodFalse() & methodTrue()); printFin(methodFalse() & methodFalse()); ", "test.zs", compileEnvironment, Test.class.getClassLoader());
             Runnable runnable = module.getMain();
             if(runnable != null)
                 runnable.run();
@@ -166,18 +160,13 @@ public class TestBoolOperators {
             registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
         }
         
-        assertMany("methodTrue", "methodTrue", "true", "Fin",
-                "methodTrue", "methodFalse", "false", "Fin",
-                "methodFalse", "methodTrue", "false", "Fin",
-                "methodFalse", "methodFalse", "false", "Fin");
+        assertMany("methodTrue", "methodTrue", "true", "Fin", "methodTrue", "methodFalse", "false", "Fin", "methodFalse", "methodTrue", "false", "Fin", "methodFalse", "methodFalse", "false", "Fin");
     }
     
     @Test
     public void TestOrOrder() {
         try {
-            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" +
-                            "printFin(methodTrue() | methodTrue()); printFin(methodTrue() | methodFalse()); printFin(methodFalse() | methodTrue()); printFin(methodFalse() | methodFalse()); ",
-                    "test.zs", compileEnvironment, Test.class.getClassLoader());
+            ZenModule module = ZenModule.compileScriptString("function methodTrue() as bool {print('methodTrue'); return true;} function methodFalse() as bool {print('methodFalse'); return false;} function printFin(a as bool) as void {print(a); print('Fin');}" + "printFin(methodTrue() | methodTrue()); printFin(methodTrue() | methodFalse()); printFin(methodFalse() | methodTrue()); printFin(methodFalse() | methodFalse()); ", "test.zs", compileEnvironment, Test.class.getClassLoader());
             Runnable runnable = module.getMain();
             if(runnable != null)
                 runnable.run();
@@ -185,18 +174,22 @@ public class TestBoolOperators {
             registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
         }
         
-        assertMany("methodTrue", "methodTrue", "true", "Fin",
-                "methodTrue", "methodFalse", "true", "Fin",
-                "methodFalse", "methodTrue", "true", "Fin",
-                "methodFalse", "methodFalse", "false", "Fin");
+        assertMany("methodTrue", "methodTrue", "true", "Fin", "methodTrue", "methodFalse", "true", "Fin", "methodFalse", "methodTrue", "true", "Fin", "methodFalse", "methodFalse", "false", "Fin");
         
         
     }
     
-    
-    private static void assertMany(String... lines) {
-        for(int i = 0; i < lines.length; i++) {
-            assertEquals(lines[i], prints.get(i));
+    @Test
+    public void TestConditional() {
+        try {
+            ZenModule module = ZenModule.compileScriptString("print(true ? 'a' : 'b'); print(false ? 'a' : 'b');" + "print(true ? 'a' : 10.0D); print(false ? 'a' : 10.0D);" + "print((true ? 10.0D : '11') + 1); print((false ? 10.0D : '11') + 1);", "test.zs", compileEnvironment, Test.class.getClassLoader());
+            Runnable runnable = module.getMain();
+            if(runnable != null)
+                runnable.run();
+        } catch(Throwable ex) {
+            registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
         }
+        
+        assertMany("a", "b", "a", "10.0", "11.0", "12.0");
     }
 }

--- a/src/test/java/stanhebben/zenscript/TestFunctions.java
+++ b/src/test/java/stanhebben/zenscript/TestFunctions.java
@@ -1,0 +1,101 @@
+package stanhebben.zenscript;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import stanhebben.zenscript.impl.GenericCompileEnvironment;
+import stanhebben.zenscript.impl.GenericErrorLogger;
+import stanhebben.zenscript.impl.GenericRegistry;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestFunctions {
+    
+    public static List<String> prints = new LinkedList<>();
+    
+    
+    public static GenericRegistry registry;
+    public static GenericErrorLogger logger;
+    public static GenericCompileEnvironment compileEnvironment;
+    
+    @SuppressWarnings("unused")
+    public static void print(String value) {
+        prints.add(value);
+    }
+    
+    @BeforeAll
+    public static void setupEnvironment() {
+        compileEnvironment = new GenericCompileEnvironment();
+        logger = new GenericErrorLogger(System.out);
+        registry = new GenericRegistry(compileEnvironment, logger);
+        registry.registerGlobal("print", registry.getStaticFunction(TestFunctions.class, "print", String.class));
+    }
+    
+    private static void assertMany(String... lines) {
+        for(int i = 0; i < lines.length; i++) {
+            assertEquals(lines[i], prints.get(i));
+        }
+    }
+    
+    @BeforeEach
+    public void clearPrints() {
+        prints.clear();
+    }
+    
+    @BeforeEach
+    public void clearClasses() {
+        ZenModule.classes.clear();
+        ZenModule.loadedClasses.clear();
+    }
+    
+    @Test
+    public void Test_NestedFunctions() {
+        try {
+            ZenModule module = ZenModule.compileScriptString("tens();  realTens(\"Hello World!\"); function tens(){     realTens(\"a\"); }  function realTens(a as string){     for i in 1 to 11{         print(a);     } }", "test.zs", compileEnvironment, Test.class.getClassLoader());
+            Runnable runnable = module.getMain();
+            if(runnable != null)
+                runnable.run();
+            
+            
+        } catch(Throwable ex) {
+            registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
+        }
+        
+        String[] expectedValues = new String[20];
+        Arrays.fill(expectedValues, 0, 10, "a");
+        Arrays.fill(expectedValues, 10, 20, "Hello World!");
+        assertMany(expectedValues);
+    }
+    
+    @Test
+    public void Test_FunctionDeclaredAfterCall() {
+        try {
+            ZenModule module = ZenModule.compileScriptString("val result = add(1,99); print(result);  print(add(2,64));  function add(a as int,b as int) as int{     return a+b; }", "test.zs", compileEnvironment, Test.class.getClassLoader());
+            Runnable runnable = module.getMain();
+            if(runnable != null)
+                runnable.run();
+        } catch(Throwable ex) {
+            registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
+        }
+        assertMany("100", "66");
+        
+    }
+    
+    @Test
+    public void Test_FunctionLargeType() {
+        try {
+            ZenModule module = ZenModule.compileScriptString("function test(a as double, b as bool) as double {return b ? a : 10.0D;} print(test(3.0D, true)); print(test(3.0D, false));", "test.zs", compileEnvironment, Test.class.getClassLoader());
+            Runnable runnable = module.getMain();
+            if(runnable != null)
+                runnable.run();
+        } catch(Throwable ex) {
+            registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
+        }
+        
+        assertMany("3.0", "10.0");
+    }
+}

--- a/src/test/java/stanhebben/zenscript/Tests.java
+++ b/src/test/java/stanhebben/zenscript/Tests.java
@@ -1,10 +1,15 @@
 package stanhebben.zenscript;
 
 
-import org.junit.jupiter.api.*;
-import stanhebben.zenscript.impl.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import stanhebben.zenscript.impl.GenericCompileEnvironment;
+import stanhebben.zenscript.impl.GenericErrorLogger;
+import stanhebben.zenscript.impl.GenericRegistry;
 
-import java.util.*;
+import java.util.LinkedList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,6 +28,11 @@ public class Tests {
         logger = new GenericErrorLogger(System.out);
         registry = new GenericRegistry(compileEnvironment, logger);
         registry.registerGlobal("print", registry.getStaticFunction(Tests.class, "print", String.class));
+    }
+    
+    @SuppressWarnings("unused")
+    public static void print(String value) {
+        prints.add(value);
     }
     
     @BeforeEach
@@ -62,7 +72,6 @@ public class Tests {
         }
         assertEquals("5", prints.get(0));
     }
-    
     
     @Test
     public void testLoop() {
@@ -189,56 +198,6 @@ public class Tests {
     }
     
     @Test
-    public void testFunctions() {
-        try {
-            ZenModule module = ZenModule.compileScriptString("tens();  realTens(\"Hello World!\");  function tens(){     realTens(\"a\"); }  function realTens(a as string){     for i in 1 to 11{         print(a);     } }", "test.zs", compileEnvironment, Test.class.getClassLoader());
-            Runnable runnable = module.getMain();
-            if(runnable != null)
-                runnable.run();
-            
-            
-        } catch(Throwable ex) {
-            registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
-        }
-        assertEquals("a", prints.get(0));
-        assertEquals("a", prints.get(1));
-        assertEquals("a", prints.get(2));
-        assertEquals("a", prints.get(3));
-        assertEquals("a", prints.get(4));
-        assertEquals("a", prints.get(5));
-        assertEquals("a", prints.get(6));
-        assertEquals("a", prints.get(7));
-        assertEquals("a", prints.get(8));
-        assertEquals("a", prints.get(9));
-        assertEquals("Hello World!", prints.get(10));
-        assertEquals("Hello World!", prints.get(11));
-        assertEquals("Hello World!", prints.get(12));
-        assertEquals("Hello World!", prints.get(13));
-        assertEquals("Hello World!", prints.get(14));
-        assertEquals("Hello World!", prints.get(15));
-        assertEquals("Hello World!", prints.get(16));
-        assertEquals("Hello World!", prints.get(17));
-        assertEquals("Hello World!", prints.get(18));
-        assertEquals("Hello World!", prints.get(19));
-    }
-    
-    @Test
-    public void testFunctionsTwo() {
-        try {
-            ZenModule module = ZenModule.compileScriptString("val result = add(1,99); print(result);  print(add(2,64));  function add(a as int,b as int) as int{     return a+b; }", "test.zs", compileEnvironment, Test.class.getClassLoader());
-            Runnable runnable = module.getMain();
-            if(runnable != null)
-                runnable.run();
-        } catch(Throwable ex) {
-            registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
-        }
-        assertEquals("100", prints.get(0));
-        assertEquals("66", prints.get(1));
-        
-    }
-    
-    
-    @Test
     public void testContains() {
         try {
             ZenModule module = ZenModule.compileScriptString("var checkthisString = \"Checking\" as string; var checkforthisString = \"ing\" as string; if (checkthisString in checkforthisString) { print(\"Yes\"); } else { print(\"No\"); }", "test.zs", compileEnvironment, Test.class.getClassLoader());
@@ -263,13 +222,13 @@ public class Tests {
         } catch(Throwable ex) {
             registry.getErrorLogger().error("Error executing: test.zs: " + ex.getMessage(), ex);
         }
-    
+        
         for(int i = 0; i < 10; i++) {
             assertEquals(Integer.toString(i), prints.get(i));
         }
         assertEquals("After loop: 10", prints.get(10));
         for(int i = 10; i > 5; i--) {
-            assertEquals(Integer.toString(i), prints.get(21-i));
+            assertEquals(Integer.toString(i), prints.get(21 - i));
         }
         assertEquals("After loop 2: 5", prints.get(16));
     }
@@ -294,16 +253,10 @@ public class Tests {
         assertEquals("123", prints.get(7));
         assertEquals("FFFFFF", prints.get(8));
         assertEquals("1", prints.get(9));
-        assertEquals( "0", prints.get(10));
-        assertEquals( "TETETE", prints.get(11));
-        assertEquals( "MYParam1", prints.get(12));
-        assertEquals( "MyPAram2", prints.get(13));
-    }
-    
-    
-    @SuppressWarnings("unused")
-    public static void print(String value) {
-        prints.add(value);
+        assertEquals("0", prints.get(10));
+        assertEquals("TETETE", prints.get(11));
+        assertEquals("MYParam1", prints.get(12));
+        assertEquals("MyPAram2", prints.get(13));
     }
     
     


### PR DESCRIPTION
LArge types (e.g. double) in function parameters should work now.
Ternary expressions now cast both expressions to the first type (I know casting the first expression to it's type doesnt do anything but maybe in the future getType will return something different (and it doesnt create an additional instruction so we're good to go) ^^)