### PR TITLE
Allow bracketed expressions in ZenType declarations.

### DIFF
--- a/src/main/java/stanhebben/zenscript/type/ZenType.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenType.java
@@ -194,6 +194,10 @@ public abstract class ZenType implements IDumpConvertable {
                 base = new ZenTypeArrayList(read(parser, environment));
                 parser.required(ZenTokener.T_SQBRCLOSE, "] expected");
                 break;
+            case ZenTokener.T_BROPEN:
+                base = read(parser, environment);
+                parser.required(ZenTokener.T_BRCLOSE, ") expected");
+                break;
             default:
                 throw new ParseException(next, "Unknown type: " + next.getValue());
         }

--- a/src/main/java/stanhebben/zenscript/type/ZenTypeArray.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeArray.java
@@ -16,7 +16,7 @@ public abstract class ZenTypeArray extends ZenType {
     
     public ZenTypeArray(ZenType base) {
         this.base = base;
-        name = base + "[]";
+        name = "(" + base + ")[]";
     }
 
     public ZenTypeArray(ZenType base, String name) {

--- a/src/main/java/stanhebben/zenscript/type/ZenTypeAssociative.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeAssociative.java
@@ -28,7 +28,7 @@ public class ZenTypeAssociative extends ZenType {
         this.valueType = valueType;
         this.keyType = keyType;
         
-        name = valueType.getName() + "[" + keyType.getName() + "]";
+        name = "(" + valueType.getName() + ")[" + keyType.getName() + "]";
     }
     
     public ZenType getValueType() {


### PR DESCRIPTION
This can reduce ambiguity and possibly allow for function arrays, or associatives with function values, if `ZenTypeFunctionCallable#toJavaClass` ever gets implemented.