### PR TITLE
Fix member access by string.

### DIFF
--- a/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
+++ b/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
@@ -256,7 +256,7 @@ public abstract class ParsedExpression {
                 break;
             }
             if(parser.optional(T_DOT) != null) {
-                Token indexString = parser.optional(T_ID, T_VERSION);
+                Token indexString = parser.optional(T_ID, T_VERSION, T_STRING);
                 if(indexString != null) {
                     base = new ParsedExpressionMember(position, base, indexString.getValue());
                 } else {

--- a/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
+++ b/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpression.java
@@ -260,7 +260,7 @@ public abstract class ParsedExpression {
                 if(indexString != null) {
                     base = new ParsedExpressionMember(position, base, indexString.getValue());
                 } else {
-                    Token indexString2 = parser.optional(T_STRING);
+                    Token indexString2 = parser.optional(T_STRINGVALUE);
                     if(indexString2 != null) {
                         base = new ParsedExpressionMember(position, base, unescapeString(indexString2.getValue()));
                     } else {


### PR DESCRIPTION
`T_STRING` is just the keyword `string`, `T_STRINGVALUE` is the token value of a string literal.