### PR TITLE
Exposed EnvironmentGlobal's ClassNameGenerator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.classpath
 *.project
 /.gradle
+/gradle
 /.settings
 /.idea
 *.iml
@@ -20,6 +21,7 @@
 *.eml
 */run/
 usernamecache.json
+gradlew
 *.stackdump
 *.log
 */.settings

--- a/src/main/java/stanhebben/zenscript/compiler/ClassNameGenerator.java
+++ b/src/main/java/stanhebben/zenscript/compiler/ClassNameGenerator.java
@@ -5,7 +5,7 @@ package stanhebben.zenscript.compiler;
  */
 public class ClassNameGenerator {
     
-    private final String prefix;
+    private String prefix;
     private int counter = 0;
     
     public ClassNameGenerator() {
@@ -13,6 +13,14 @@ public class ClassNameGenerator {
     }
     
     public ClassNameGenerator(String prefix) {
+        this.prefix = prefix;
+    }
+    
+    public String getPrefix() {
+        return prefix;
+    }
+    
+    public void setPrefix(String prefix) {
         this.prefix = prefix;
     }
     

--- a/src/main/java/stanhebben/zenscript/compiler/EnvironmentClass.java
+++ b/src/main/java/stanhebben/zenscript/compiler/EnvironmentClass.java
@@ -46,6 +46,11 @@ public class EnvironmentClass implements IEnvironmentClass {
     }
     
     @Override
+    public ClassNameGenerator getClassNameGenerator() {
+        return global.getClassNameGenerator();
+    }
+    
+    @Override
     public String makeClassName() {
         return global.makeClassName();
     }

--- a/src/main/java/stanhebben/zenscript/compiler/EnvironmentGlobal.java
+++ b/src/main/java/stanhebben/zenscript/compiler/EnvironmentGlobal.java
@@ -50,6 +50,11 @@ public class EnvironmentGlobal implements IEnvironmentGlobal {
     }
     
     @Override
+    public ClassNameGenerator getClassNameGenerator() {
+        return nameGen;
+    }
+    
+    @Override
     public String makeClassName() {
         return nameGen.generate();
     }

--- a/src/main/java/stanhebben/zenscript/compiler/EnvironmentMethod.java
+++ b/src/main/java/stanhebben/zenscript/compiler/EnvironmentMethod.java
@@ -77,6 +77,11 @@ public class EnvironmentMethod implements IEnvironmentMethod {
     }
     
     @Override
+    public ClassNameGenerator getClassNameGenerator() {
+        return environment.getClassNameGenerator();
+    }
+    
+    @Override
     public String makeClassName() {
         return environment.makeClassName();
     }

--- a/src/main/java/stanhebben/zenscript/compiler/EnvironmentScope.java
+++ b/src/main/java/stanhebben/zenscript/compiler/EnvironmentScope.java
@@ -60,6 +60,11 @@ public class EnvironmentScope implements IEnvironmentMethod {
     }
     
     @Override
+    public ClassNameGenerator getClassNameGenerator() {
+        return outer.getClassNameGenerator();
+    }
+    
+    @Override
     public String makeClassName() {
         return outer.makeClassName();
     }

--- a/src/main/java/stanhebben/zenscript/compiler/EnvironmentScript.java
+++ b/src/main/java/stanhebben/zenscript/compiler/EnvironmentScript.java
@@ -33,6 +33,11 @@ public class EnvironmentScript implements IEnvironmentGlobal {
     }
     
     @Override
+    public ClassNameGenerator getClassNameGenerator() {
+        return parent.getClassNameGenerator();
+    }
+    
+    @Override
     public String makeClassName() {
         return parent.makeClassName();
     }

--- a/src/main/java/stanhebben/zenscript/compiler/IEnvironmentGlobal.java
+++ b/src/main/java/stanhebben/zenscript/compiler/IEnvironmentGlobal.java
@@ -16,6 +16,8 @@ public interface IEnvironmentGlobal extends ITypeRegistry, IZenErrorLogger {
     
     TypeExpansion getExpansion(String name);
     
+    ClassNameGenerator getClassNameGenerator();
+    
     String makeClassName();
     
     String makeClassNameWithMiddleName(String middleName);

--- a/src/main/java/stanhebben/zenscript/impl/GenericGlobalEnvironment.java
+++ b/src/main/java/stanhebben/zenscript/impl/GenericGlobalEnvironment.java
@@ -35,6 +35,11 @@ public class GenericGlobalEnvironment implements IEnvironmentGlobal {
     }
     
     @Override
+    public ClassNameGenerator getClassNameGenerator() {
+        return generator;
+    }
+    
+    @Override
     public String makeClassName() {
         return generator.generate();
     }


### PR DESCRIPTION
Needed for multi-loader CraftTweaker PR in order to prevent class name conflicts acrosss multiple loader executions.