### PR TITLE
add expansion methods

### DIFF
--- a/src/main/java/stanhebben/zenscript/TypeExpansion.java
+++ b/src/main/java/stanhebben/zenscript/TypeExpansion.java
@@ -4,6 +4,7 @@ import org.objectweb.asm.*;
 import org.objectweb.asm.Type;
 import stanhebben.zenscript.annotations.*;
 import stanhebben.zenscript.compiler.*;
+import stanhebben.zenscript.definitions.ParsedExpansion;
 import stanhebben.zenscript.expression.*;
 import stanhebben.zenscript.expression.partial.IPartialExpression;
 import stanhebben.zenscript.type.ZenType;
@@ -28,6 +29,7 @@ public class TypeExpansion {
     private final String type;
     private final Map<String, ZenExpandMember> members;
     private final Map<String, ZenExpandMember> staticMembers;
+    private final Map<String, ParsedExpansion> zenMembers;
     private final List<ZenExpandCaster> casters;
     private final List<ZenNativeOperator> trinaryOperators;
     private final List<ZenNativeOperator> binaryOperators;
@@ -44,6 +46,7 @@ public class TypeExpansion {
         
         members = new HashMap<>();
         staticMembers = new HashMap<>();
+        zenMembers = new HashMap<>();
         casters = new ArrayList<>();
         trinaryOperators = new ArrayList<>();
         binaryOperators = new ArrayList<>();
@@ -200,6 +203,10 @@ public class TypeExpansion {
         }
     }
 
+    public void addZenExpandMethod(String name, ParsedExpansion expansion) {
+        zenMembers.put(name, expansion);
+    }
+
     private void checkGetter(Method method, Class cls) {
         if (method.getReturnType().equals(Void.TYPE)){
             throw new RuntimeException("ZenGetter needs a non Void returntype - " + cls.getName() + "." + method.getName());
@@ -336,6 +343,9 @@ public class TypeExpansion {
     public IPartialExpression instanceMember(ZenPosition position, IEnvironmentGlobal environment, Expression value, String member) {
         if(members.containsKey(member)) {
             return members.get(member).instance(position, environment, value);
+        }
+        if (zenMembers.containsKey(member)) {
+            return zenMembers.get(member).instance(position, value);
         }
         
         return null;

--- a/src/main/java/stanhebben/zenscript/ZenParsedFile.java
+++ b/src/main/java/stanhebben/zenscript/ZenParsedFile.java
@@ -142,12 +142,14 @@ public class ZenParsedFile {
                 parsedZenClass.writeClass(environmentScript);
             } else if (next.getType() == T_DOLLAR) {
                 ParsedExpansion expansion = ParsedExpansion.parse(tokener, environmentScript, this);
+                String name = expansion.getName();
+                String compileName = expansion.getCompileName();
                 ParsedFunction function = expansion.getFunction();
-                if (functions.containsKey(function.getName())) {
-                    environmentScript.error(function.getPosition(), "function " + function.getName() + " already exists");
+                if (functions.containsKey(compileName)) {
+                    environmentScript.error(function.getPosition(), "expand method  " + name + " already exists");
                 }
-                functions.put(function.getName(), function);
-                environmentScript.getExpansion(expansion.getType().getName()).addZenExpandMethod(expansion.getName(), expansion);
+                functions.put(compileName, function);
+                environmentScript.getExpansion(expansion.getType().getName()).addZenExpandMethod(name, expansion);
             } else {
                 statements.add(Statement.read(tokener, environmentScript, null));
             }

--- a/src/main/java/stanhebben/zenscript/compiler/TypeRegistry.java
+++ b/src/main/java/stanhebben/zenscript/compiler/TypeRegistry.java
@@ -2,6 +2,7 @@ package stanhebben.zenscript.compiler;
 
 import stanhebben.zenscript.type.*;
 import stanhebben.zenscript.value.IAny;
+import stanhebben.zenscript.value.IntRange;
 
 import java.lang.reflect.*;
 import java.util.*;
@@ -37,6 +38,7 @@ public class TypeRegistry implements ITypeRegistry {
         
         types.put(String.class, ZenTypeString.INSTANCE);
         types.put(List.class, new ZenTypeArrayBasic(ZenTypeAny.INSTANCE));
+        types.put(IntRange.class, ZenTypeIntRange.INSTANCE);
     }
     
     public ZenType getClassType(Class cls) {

--- a/src/main/java/stanhebben/zenscript/definitions/ParsedExpansion.java
+++ b/src/main/java/stanhebben/zenscript/definitions/ParsedExpansion.java
@@ -9,6 +9,7 @@ import stanhebben.zenscript.expression.partial.PartialExpansionCall;
 import stanhebben.zenscript.parser.ParseException;
 import stanhebben.zenscript.parser.Token;
 import stanhebben.zenscript.type.ZenType;
+import stanhebben.zenscript.type.ZenTypeArrayBasic;
 import stanhebben.zenscript.util.ZenPosition;
 
 import java.util.ArrayList;
@@ -50,6 +51,16 @@ public class ParsedExpansion {
         return function.getName();
     }
 
+    public String getCompileName() {
+        String typeName;
+        if (type instanceof ZenTypeArrayBasic) {
+            typeName = "array$" + ((ZenTypeArrayBasic) type).getBaseType().toJavaClass().getSimpleName();
+        } else {
+            typeName = type.toJavaClass().getSimpleName();
+        }
+        return "expand$" + typeName + "$" + getName();
+    }
+
     public ParsedFunction getFunction() {
         return function;
     }
@@ -63,6 +74,6 @@ public class ParsedExpansion {
     }
 
     public IPartialExpression instance(ZenPosition position, Expression value) {
-        return new PartialExpansionCall(position, owner, getName(), function.getSignature(), function.getArguments(), function.getReturnType(), value);
+        return new PartialExpansionCall(position, owner, getCompileName(), function.getSignature(), function.getArguments(), function.getReturnType(), value);
     }
 }

--- a/src/main/java/stanhebben/zenscript/definitions/ParsedExpansion.java
+++ b/src/main/java/stanhebben/zenscript/definitions/ParsedExpansion.java
@@ -1,0 +1,68 @@
+package stanhebben.zenscript.definitions;
+
+import stanhebben.zenscript.ZenParsedFile;
+import stanhebben.zenscript.ZenTokener;
+import stanhebben.zenscript.compiler.IEnvironmentGlobal;
+import stanhebben.zenscript.expression.Expression;
+import stanhebben.zenscript.expression.partial.IPartialExpression;
+import stanhebben.zenscript.expression.partial.PartialExpansionCall;
+import stanhebben.zenscript.parser.ParseException;
+import stanhebben.zenscript.parser.Token;
+import stanhebben.zenscript.type.ZenType;
+import stanhebben.zenscript.util.ZenPosition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author youyihj
+ */
+public class ParsedExpansion {
+    private final ParsedFunction function;
+    private final ZenType type;
+    private final String owner;
+
+    public ParsedExpansion(ParsedFunction function, ZenType type, ZenParsedFile owner) {
+        this.function = function;
+        this.type = type;
+        this.owner = owner.getClassName();
+    }
+
+    public static ParsedExpansion parse(ZenTokener parser, IEnvironmentGlobal environment, ZenParsedFile owner) {
+        parser.next();
+        Token expandKeyword = parser.next();
+        if (expandKeyword.getType() != ZenTokener.T_ID || !expandKeyword.getValue().equals("expand")) {
+            throw new ParseException(expandKeyword, "expand expected");
+        }
+        ZenType type = ZenType.read(parser, environment);
+        Token token = parser.peek();
+        if (token.getType() != ZenTokener.T_DOLLAR) {
+            throw new ParseException(token, "$ expected");
+        }
+        List<ParsedFunctionArgument> arguments = new ArrayList<>();
+        arguments.add(new ParsedFunctionArgument("this", type, null));
+        ParsedFunction function = ParsedFunction.parse(parser, environment, arguments);
+
+        return new ParsedExpansion(function, type, owner);
+    }
+
+    public String getName() {
+        return function.getName();
+    }
+
+    public ParsedFunction getFunction() {
+        return function;
+    }
+
+    public ZenType getType() {
+        return type;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public IPartialExpression instance(ZenPosition position, Expression value) {
+        return new PartialExpansionCall(position, owner, getName(), function.getSignature(), function.getArguments(), function.getReturnType(), value);
+    }
+}

--- a/src/main/java/stanhebben/zenscript/definitions/ParsedExpansion.java
+++ b/src/main/java/stanhebben/zenscript/definitions/ParsedExpansion.java
@@ -9,7 +9,6 @@ import stanhebben.zenscript.expression.partial.PartialExpansionCall;
 import stanhebben.zenscript.parser.ParseException;
 import stanhebben.zenscript.parser.Token;
 import stanhebben.zenscript.type.ZenType;
-import stanhebben.zenscript.type.ZenTypeArrayBasic;
 import stanhebben.zenscript.util.ZenPosition;
 
 import java.util.ArrayList;
@@ -52,13 +51,7 @@ public class ParsedExpansion {
     }
 
     public String getCompileName() {
-        String typeName;
-        if (type instanceof ZenTypeArrayBasic) {
-            typeName = "array$" + ((ZenTypeArrayBasic) type).getBaseType().toJavaClass().getSimpleName();
-        } else {
-            typeName = type.toJavaClass().getSimpleName();
-        }
-        return "expand$" + typeName + "$" + getName();
+        return "expand$" + type.getNameForInterfaceSignature() + "$" + getName();
     }
 
     public ParsedFunction getFunction() {

--- a/src/main/java/stanhebben/zenscript/definitions/ParsedFunction.java
+++ b/src/main/java/stanhebben/zenscript/definitions/ParsedFunction.java
@@ -44,6 +44,10 @@ public class ParsedFunction {
     }
 
     public static ParsedFunction parse(ZenTokener parser, IEnvironmentGlobal environment) {
+        return ParsedFunction.parse(parser, environment, new ArrayList<>());
+    }
+
+    static ParsedFunction parse(ZenTokener parser, IEnvironmentGlobal environment, List<ParsedFunctionArgument> arguments) {
         parser.next();
         Token tName = parser.required(ZenTokener.T_ID, "identifier expected");
 
@@ -51,7 +55,6 @@ public class ParsedFunction {
         // ...contents... }
         parser.required(T_BROPEN, "( expected");
 
-        List<ParsedFunctionArgument> arguments = new ArrayList<>();
         if(parser.optional(T_BRCLOSE) == null) {
             Token argName = parser.required(T_ID, "identifier expected");
             ZenType type = ZenTypeAny.INSTANCE;

--- a/src/main/java/stanhebben/zenscript/expression/partial/PartialExpansionCall.java
+++ b/src/main/java/stanhebben/zenscript/expression/partial/PartialExpansionCall.java
@@ -1,0 +1,29 @@
+package stanhebben.zenscript.expression.partial;
+
+import stanhebben.zenscript.compiler.IEnvironmentMethod;
+import stanhebben.zenscript.definitions.ParsedFunctionArgument;
+import stanhebben.zenscript.expression.Expression;
+import stanhebben.zenscript.type.ZenType;
+import stanhebben.zenscript.util.ZenPosition;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author youyihj
+ */
+public class PartialExpansionCall extends PartialStaticGenerated {
+    private final Expression instance;
+
+    public PartialExpansionCall(ZenPosition position, String owner, String method, String signature, List<ParsedFunctionArgument> arguments, ZenType returnType, Expression instance) {
+        super(position, owner, method, signature, arguments, returnType);
+        this.instance = instance;
+    }
+
+    @Override
+    public Expression call(ZenPosition position, IEnvironmentMethod environment, Expression... values) {
+        Expression[] expressions = Arrays.copyOf(new Expression[] {instance}, values.length + 1);
+        System.arraycopy(values, 0, expressions, 1, values.length);
+        return super.call(position, environment, expressions);
+    }
+}

--- a/src/main/java/stanhebben/zenscript/impl/GenericCompileEnvironment.java
+++ b/src/main/java/stanhebben/zenscript/impl/GenericCompileEnvironment.java
@@ -40,7 +40,7 @@ public class GenericCompileEnvironment implements IZenCompileEnvironment {
     
     @Override
     public TypeExpansion getExpansion(String type) {
-        return registry.getExpansions().get(type);
+        return registry.getExpansions().computeIfAbsent(type, TypeExpansion::new);
     }
     
     public IZenRegistry getRegistry() {

--- a/src/main/java/stanhebben/zenscript/impl/GenericGlobalEnvironment.java
+++ b/src/main/java/stanhebben/zenscript/impl/GenericGlobalEnvironment.java
@@ -31,7 +31,7 @@ public class GenericGlobalEnvironment implements IEnvironmentGlobal {
     
     @Override
     public TypeExpansion getExpansion(String name) {
-        return registry.getExpansions().get(name);
+        return registry.getExpansions().computeIfAbsent(name, TypeExpansion::new);
     }
     
     @Override

--- a/src/main/java/stanhebben/zenscript/impl/GenericRegistry.java
+++ b/src/main/java/stanhebben/zenscript/impl/GenericRegistry.java
@@ -2,18 +2,20 @@ package stanhebben.zenscript.impl;
 
 import stanhebben.zenscript.*;
 import stanhebben.zenscript.annotations.ZenExpansion;
-import stanhebben.zenscript.compiler.*;
+import stanhebben.zenscript.compiler.IEnvironmentGlobal;
+import stanhebben.zenscript.compiler.TypeRegistry;
 import stanhebben.zenscript.parser.Token;
 import stanhebben.zenscript.symbols.*;
+import stanhebben.zenscript.type.ZenTypeIntRange;
 import stanhebben.zenscript.type.ZenTypeNative;
-import stanhebben.zenscript.type.natives.*;
+import stanhebben.zenscript.type.natives.IJavaMethod;
+import stanhebben.zenscript.type.natives.JavaMethod;
 import stanhebben.zenscript.util.Pair;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.*;
 import java.util.function.ToIntFunction;
-import java.util.logging.*;
 
 public class GenericRegistry implements IZenRegistry {
     
@@ -31,13 +33,13 @@ public class GenericRegistry implements IZenRegistry {
         this.compileEnvironment = compileEnvironment;
         this.errorLogger = errorLogger;
         this.compileEnvironment.setRegistry(this);
+        this.root.put(ZenTypeIntRange.INSTANCE.getName(), new SymbolType(ZenTypeIntRange.INSTANCE), this.errorLogger);
     }
     
     public void registerGlobal(String name, IZenSymbol symbol) {
         if(globals.containsKey(name)) {
             throw new IllegalArgumentException("symbol already exists: " + name);
         }
-        
         globals.put(name, symbol);
     }
     

--- a/src/main/java/stanhebben/zenscript/type/ZenTypeAssociative.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeAssociative.java
@@ -115,15 +115,14 @@ public class ZenTypeAssociative extends ZenType {
             return new ExpressionMapSize(position, value.eval(environment));
         }else if(name.equals("keySet") || name.equals("values") || name.equals("keys") || name.equals("valueSet") || name.equals("entrySet")) {
             return new ExpressionMapEntrySet(position, value.eval(environment), name);
-        } else if(STRING.canCastImplicit(keyType, environment)) {
-            return new ExpressionMapIndexGet(position, value.eval(environment), new ExpressionString(position, name).cast(position, environment, keyType));
         } else {
             IPartialExpression result = memberExpansion(position, environment, value.eval(environment), name);
-            if(result == null) {
+            if (result != null) return result;
+            if (STRING.canCastImplicit(keyType, environment)) {
+                return new ExpressionMapIndexGet(position, value.eval(environment), new ExpressionString(position, name).cast(position, environment, keyType));
+            } else {
                 environment.error(position, "this array is not indexable with strings");
                 return new ExpressionInvalid(position, valueType);
-            } else {
-                return result;
             }
         }
     }

--- a/src/test/java/stanhebben/zenscript/tests/TestExpansion.java
+++ b/src/test/java/stanhebben/zenscript/tests/TestExpansion.java
@@ -1,0 +1,44 @@
+package stanhebben.zenscript.tests;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import stanhebben.zenscript.TestAssertions;
+import stanhebben.zenscript.TestHelper;
+
+import java.util.StringJoiner;
+
+public class TestExpansion {
+    @BeforeAll
+    public static void setupEnvironment() {
+        TestHelper.setupEnvironment();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        TestHelper.beforeEach();
+    }
+
+    @Test
+    public void testExpansion() {
+        StringJoiner joiner = new StringJoiner("\n")
+                .add("$expand string$wrap(prefix as string, suffix as string) as string {")
+                .add("    return prefix ~ this ~ suffix;")
+                .add("}")
+                .add("print(\"test\".wrap(\"[\", \"]\"));");
+        TestHelper.run(joiner.toString());
+        TestAssertions.assertMany("[test]");
+    }
+
+    @Test
+    public void testExpansionDefaultArguments() {
+        StringJoiner joiner = new StringJoiner("\n")
+                .add("$expand string$wrap(prefix as string = \"(\", suffix as string = \")\") as string {")
+                .add("    return prefix ~ this ~ suffix;")
+                .add("}")
+                .add("print(\"test\".wrap(\"[\", \"]\"));")
+                .add("print(\"test\".wrap());");
+        TestHelper.run(joiner.toString());
+        TestAssertions.assertMany("[test]", "(test)");
+    }
+}


### PR DESCRIPTION
This PR allows to add new methods to an existed type.
Example:
```zenscript
import crafttweaker.item.IItemStack;

$expand IItemStack$show() as void {
    print(this.commandString);
}

$expand string$wrap(prefix as string = "(", suffix as string = ")") as string {
    return prefix ~ this ~ suffix;
}

<item:minecraft:apple>.show();
print("test".wrap());
print("test".wrap("[", "]"));
```
The PR reads $ first and checks if the identifier after it is `expand`. It doesn't add a new keyword and shouldn't cause incompatibilities.