### PR TITLE
Fix function fields in zenclasses overlapping.

### DIFF
--- a/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpressionFunction.java
+++ b/src/main/java/stanhebben/zenscript/parser/expression/ParsedExpressionFunction.java
@@ -60,7 +60,7 @@ public class ParsedExpressionFunction extends ParsedExpression {
             }
         } else {
             if(predictedType instanceof ZenTypeFunctionCallable) {
-                return new ExpressionFunction(getPosition(), arguments, returnType, statements, ((ZenTypeFunctionCallable) predictedType).getClassName());
+                return new ExpressionFunction(getPosition(), arguments, returnType, statements,  environment.makeClassNameWithMiddleName(((ZenTypeFunctionCallable) predictedType).getClassName()));
             }
             System.out.println("No known predicted type");
             return new ExpressionFunction(getPosition(), arguments, returnType, statements, environment.makeClassNameWithMiddleName(getPosition().getFile().getClassName()));


### PR DESCRIPTION
Closes https://github.com/CraftTweaker/CraftTweaker/issues/1010

The issue is that the functions themselves were using the same name and were overwriting each other.

All tests pass with this fix and it has been tested to at-least compile and load scripts in production (tested with the latest sevtech modpack).