### PR TITLE
Fix for loop runs at least once

### DIFF
--- a/src/main/java/stanhebben/zenscript/type/ZenTypeIntRange.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeIntRange.java
@@ -175,20 +175,19 @@ public class ZenTypeIntRange extends ZenType {
         
         @Override
         public void compilePreIterate(int[] locals, Label exit) {
-            
+            MethodOutput output = method.getOutput();
+
+            output.dup(); // copy limit
+            output.loadInt(locals[0]);
+            output.ifICmpLE(exit);
         }
         
         @Override
         public void compilePostIterate(int[] locals, Label exit, Label repeat) {
             MethodOutput output = method.getOutput();
-            
-            output.dup(); // copy limit
-            
+
             output.iinc(locals[0]);
-            output.loadInt(locals[0]);
-            
-            output.ifICmpGT(repeat);
-            output.goTo(exit);
+            output.goTo(repeat);
         }
         
         @Override


### PR DESCRIPTION
```zenscript
for i in 0 .. 0 {
    print(i);
}
```

It prints 0 instead of doing nothing