### PR TITLE
fix function object is not accepted by function receiving `java.lang.Object`

### DIFF
--- a/src/main/java/stanhebben/zenscript/type/ZenTypeFunction.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeFunction.java
@@ -208,7 +208,7 @@ public class ZenTypeFunction extends ZenType {
     @Override
     public Class toJavaClass() {
         // TODO: complete
-        return null;
+        return Object.class;
     }
     
     @Override

--- a/src/main/java/stanhebben/zenscript/type/ZenTypeFunctionCallable.java
+++ b/src/main/java/stanhebben/zenscript/type/ZenTypeFunctionCallable.java
@@ -91,7 +91,7 @@ public class ZenTypeFunctionCallable extends ZenTypeFunction {
     @Override
     public Class toJavaClass() {
         // TODO: complete
-        return null;
+        return Object.class;
     }
     
     @Override


### PR DESCRIPTION
```zenscript
val foo as function()int = function() as int { return 0; };

print(isNull(foo)); // error
```