### PR TITLE
apply cast in return statement

### DIFF
--- a/src/main/java/stanhebben/zenscript/statements/StatementReturn.java
+++ b/src/main/java/stanhebben/zenscript/statements/StatementReturn.java
@@ -35,7 +35,7 @@ public class StatementReturn extends Statement {
         if(expression == null) {
             environment.getOutput().ret();
         } else {
-            Expression cExpression = expression.compile(environment, returnType).eval(environment);
+            Expression cExpression = expression.compile(environment, returnType).eval(environment).cast(getPosition(), environment, returnType);
             cExpression.compile(true, environment);
             
             Type returnType = cExpression.getType().toASMType();


### PR DESCRIPTION
```zenscript
static map as int[string] = {
    "a": 1,
    "b": 2,
    "c": 3
};

function mapGet(key as string) as int {
    return map[key];
}

print(mapGet("a")); // error: Type 'java/lang/Integer' (current frame, stack[0]) is not assignable to integer (from method signature)
```